### PR TITLE
feat: auto-open collection release PRs

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -3,11 +3,14 @@
 name: Prepare collection release
 
 on:
+  push:
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       version:
-        description: Release version, for example 1.2.3
-        required: true
+        description: Release version, for example 1.2.3. Leave empty on manual runs to calculate the next feature version.
+        required: false
+        default: ""
       base_branch:
         description: Base branch. Leave empty to prefer develop, then main.
         required: false
@@ -37,6 +40,12 @@ jobs:
   prepare:
     name: Prepare release PR
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+      )
     env:
       RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -90,41 +99,92 @@ jobs:
           python -m pip install ansible-core antsibull-changelog pyyaml
 
       - name: Prepare release branch
+        id: prepare-release
         env:
           GH_TOKEN: ${{ steps.token.outputs.value }}
-          VERSION: ${{ inputs.version }}
-          BASE_BRANCH_INPUT: ${{ inputs.base_branch }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
-          CREATE_GITHUB_RELEASE: ${{ inputs.create_github_release == 'true' }}
-          PUBLISH_GALAXY: ${{ inputs.publish_galaxy == 'true' }}
+          VERSION_INPUT: ${{ github.event.inputs.version }}
+          BASE_BRANCH_INPUT: ${{ github.event.inputs.base_branch }}
+          TARGET_BRANCH_INPUT: ${{ github.event.inputs.target_branch }}
+          CREATE_GITHUB_RELEASE_INPUT: ${{ github.event.inputs.create_github_release }}
+          PUBLISH_GALAXY_INPUT: ${{ github.event.inputs.publish_galaxy }}
+          AUTO_RELEASE_BUMP: minor
         run: |
           set -euo pipefail
 
+          VERSION="${VERSION_INPUT:-}"
           case "$VERSION" in
             v*) VERSION="${VERSION#v}" ;;
           esac
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Version must be semantic versioning, for example 1.2.3."
-            exit 1
-          fi
-          if [ "$TARGET_BRANCH" != "main" ]; then
-            echo "::error::Collection release PRs must target main."
-            exit 1
-          fi
+          TARGET_BRANCH="${TARGET_BRANCH_INPUT:-main}"
+          CREATE_GITHUB_RELEASE="${CREATE_GITHUB_RELEASE_INPUT:-true}"
+          PUBLISH_GALAXY="${PUBLISH_GALAXY_INPUT:-false}"
 
-          if [ -n "$BASE_BRANCH_INPUT" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            BASE_BRANCH="main"
+          elif [ -n "$BASE_BRANCH_INPUT" ]; then
             BASE_BRANCH="$BASE_BRANCH_INPUT"
           elif git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
             BASE_BRANCH="develop"
           else
             BASE_BRANCH="$TARGET_BRANCH"
           fi
-
-          RELEASE_BRANCH="release/v${VERSION}"
+          if [ "$TARGET_BRANCH" != "main" ]; then
+            echo "::error::Collection release PRs must target main."
+            exit 1
+          fi
 
           git config user.name "litreleasebot"
           git config user.email "litreleasebot@users.noreply.github.com"
           git fetch origin "$BASE_BRANCH" "$TARGET_BRANCH"
+          git switch -C release-prepare-base "origin/$BASE_BRANCH"
+
+          fragment_count="$(
+            find changelogs/fragments \
+              -maxdepth 1 \
+              -type f \
+              \( -name '*.yml' -o -name '*.yaml' \) \
+              ! -name '.gitkeep' \
+              | wc -l
+          )"
+          if [ "$fragment_count" -eq 0 ]; then
+            echo "No changelog fragments found; no collection release PR needed."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "$VERSION" ]; then
+            VERSION="$(
+              python - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+          import yaml
+
+          data = yaml.safe_load(Path("galaxy.yml").read_text()) or {}
+          current = str(data.get("version", "")).removeprefix("v")
+          match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:[-.][0-9A-Za-z.-]+)?", current)
+          if not match:
+              raise SystemExit(f"Cannot calculate next version from galaxy.yml version: {current!r}")
+          major, minor, patch = map(int, match.groups())
+          bump = os.environ.get("AUTO_RELEASE_BUMP", "minor")
+          if bump == "major":
+              print(f"{major + 1}.0.0")
+          elif bump == "patch":
+              print(f"{major}.{minor}.{patch + 1}")
+          else:
+              print(f"{major}.{minor + 1}.0")
+          PY
+            )"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version must be semantic versioning, for example 1.2.3."
+            exit 1
+          fi
+          export VERSION
+
+          RELEASE_BRANCH="release/v${VERSION}"
+          echo "Preparing release PR for v${VERSION} from ${BASE_BRANCH} to ${TARGET_BRANCH}."
+
           git switch -C "$RELEASE_BRANCH" "origin/$BASE_BRANCH"
 
           python - <<'PY'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,13 @@ If generic guidance conflicts with repository behavior, you MUST prefer reposito
    3. legacy `CHANGELOG.md` files where they still exist.
 10. Generated changelog files and `galaxy.yml` version bumps are release-PR changes only.
 11. Release preparation MUST happen on `release/vX.Y.Z` branches and open a PR into `main`.
-12. Publishing happens only after the release PR is merged into `main`.
-13. No workflow or agent may push release commits directly to `main`.
-14. GitHub Release notes are an additional publishing surface; they MUST be generated from or aligned with the
+12. The release preparation workflow MAY automatically create that PR after a push to `main` when unreleased
+    changelog fragments exist.
+13. Publishing happens only after the release PR is merged into `main`.
+14. No workflow or agent may push release commits directly to `main`.
+15. GitHub Release notes are an additional publishing surface; they MUST be generated from or aligned with the
    repository changelog, not used as the only changelog.
-15. GitHub repository settings, branch protection, required checks, workflow permissions, labels, environments,
+16. GitHub repository settings, branch protection, required checks, workflow permissions, labels, environments,
     secrets, and release-bot permissions MUST be changed only through `github-management-lit`.
 
 ## 2.1 Production Review Standard (Community, Red Hat, Efficiency)
@@ -245,7 +247,8 @@ The standard branch and release model is:
 - Promotion from `develop` to `main` must happen through a pull request.
 - Promotion pull requests must remain a human-visible manual merge checkpoint after required checks pass.
 - Do not direct-push from `develop` to `main`.
-- Collection releases must be prepared from `release/vX.Y.Z` branches with `antsibull-changelog`.
+- Collection release PRs are created automatically from `release/vX.Y.Z` branches after `main` receives unreleased
+  changelog fragments.
 - Release PRs target `main` and must pass required checks before merge.
 
 Automation safety requirements:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,14 @@ sweeps, do them in a separate PR.
   are useful PR conventions, but releases are explicit maintainer actions so the
   collection changelog, `galaxy.yml` version, release branch, and Galaxy
   publication stay aligned.
-- Release preparation is manual via the **Prepare collection release** workflow.
-- The workflow creates or updates a `release/vX.Y.Z` branch, runs
-  `antsibull-changelog release`, bumps `galaxy.yml`, builds the collection, and
-  opens a release PR into `main`.
+- Release preparation is automatic after feature changes are merged to `main`:
+  the **Prepare collection release** workflow opens a `release/vX.Y.Z` PR when
+  unreleased changelog fragments exist.
+- The workflow calculates the next feature version by default, creates or
+  updates a `release/vX.Y.Z` branch, runs `antsibull-changelog release`, bumps
+  `galaxy.yml`, builds the collection, and opens a release PR into `main`.
+- Maintainers may still run the workflow manually to choose an explicit version
+  or retry a release preparation.
 - Do **not** push release commits directly to `main`.
 - GitHub Release notes are generated from the repository changelog content after
   the release PR is merged.


### PR DESCRIPTION
Render the shared-assets-lit release workflow update from lightning-it/shared-assets-lit#188.\n\nAfter this reaches main, pushes to main with unreleased changelog fragments will automatically open a release/vX.Y.Z PR using the next feature version. Release commits still go through a PR and are not pushed directly to main.