### PR TITLE
fix: make foundational helpers lint clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,11 +367,11 @@ For service/application lifecycle roles, prefer this role family layout:
 Use only applicable roles. For databases such as PostgreSQL, omit `_cac` by default unless there is real declarative
 object reconciliation.
 
-For containerized service/application lifecycle roles, use `lit.foundational.kubeplay` as the default execution path
-for Podman kube actions (`run`, `recreate`, `restart`, and `remove`). Deploy, ops, upgrade, and destroy roles SHOULD
-render pod manifests and call kubeplay with explicit `kubeplay_apps` entries. Direct `podman kube play`,
-`podman pod restart`, or `podman pod rm` commands are allowed only as documented compatibility exceptions
-or inside the `lit.foundational.kubeplay` implementation itself.
+For persistent containerized service/application lifecycle roles, use `lit.foundational.podman_systemd` as the
+default execution path. Deploy roles SHOULD render Podman kube manifests and hand persistent startup, enablement,
+restart, stop, and removal to `podman_systemd` through Quadlet/systemd. `lit.foundational.kubeplay` is reserved for
+non-persistent/manual runtime actions, tests, compatibility exceptions, and emergency operations where systemd is not
+available.
 
 ## 4. Role Structure and Prechecks
 

--- a/changelogs/fragments/foundational-tls-secret-helpers.yml
+++ b/changelogs/fragments/foundational-tls-secret-helpers.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added generic tls_assets, vault_pki_cert, secret_backend, and secret_kv foundational roles for reusable TLS and secret handling.

--- a/changelogs/fragments/foundational-tls-secret-helpers.yml
+++ b/changelogs/fragments/foundational-tls-secret-helpers.yml
@@ -1,3 +1,5 @@
 ---
 minor_changes:
-  - Added generic tls_assets, vault_pki_cert, secret_backend, and secret_kv foundational roles for reusable TLS and secret handling.
+  - >-
+    Added generic tls_assets, vault_pki_cert, secret_backend, and secret_kv
+    foundational roles for reusable TLS and secret handling.

--- a/changelogs/fragments/podman-systemd-role.yml
+++ b/changelogs/fragments/podman-systemd-role.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added the podman_systemd role for persistent Podman kube services through Quadlet and systemd.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lit
 name: foundational
-version: 1.24.0
+version: 1.25.0
 readme: README.md
 description: Foundational Ansible collection for ModuLix, providing base roles, helpers,
   and Terraform/Terragrunt runner building blocks for platform automation.
@@ -17,10 +17,12 @@ tags:
   - automation
 dependencies:
   community.general: '>=11.4.9,<12.0.0'
+  community.crypto: '>=3.2.2,<4.0.0'
   ansible.posix: '>=2.2.0'
   community.docker: '*'
   community.vmware: 5.10.0
   vmware.vmware: '>=2.9.0'
+  community.hashi_vault: '*'
 build_ignore:
   - .ansible
   - .cache

--- a/roles/kubeplay/tasks/apps/podman_kube_play.yml
+++ b/roles/kubeplay/tasks/apps/podman_kube_play.yml
@@ -32,7 +32,7 @@
 - name: Remove pod before kube play
   ansible.builtin.command: "podman pod rm -f {{ _kubeplay_pod_name }}"
   register: kubeplay_pod_remove
-  failed_when: kubeplay_pod_remove.rc not in [0, 125]
+  failed_when: kubeplay_pod_remove.rc not in [0, 1, 2, 125]
   changed_when: "'deleted' in kubeplay_pod_remove.stdout"
   when: _kubeplay_action in ['recreate', 'remove']
 

--- a/roles/kubeplay/tasks/apps/podman_kube_play.yml
+++ b/roles/kubeplay/tasks/apps/podman_kube_play.yml
@@ -1,8 +1,16 @@
 ---
 - name: Normalize kubeplay podman action variables
   ansible.builtin.set_fact:
-    _kubeplay_action: "{{ kubeplay_action | default((kubeplay_app.vars | default({})).kubeplay_action | default('')) }}"
-    _kubeplay_pod_name: "{{ kubeplay_pod_name | default((kubeplay_app.vars | default({})).kubeplay_pod_name | default('')) }}"
+    _kubeplay_action: >-
+      {{
+        kubeplay_action
+        | default((kubeplay_app.vars | default({})).kubeplay_action | default(''))
+      }}
+    _kubeplay_pod_name: >-
+      {{
+        kubeplay_pod_name
+        | default((kubeplay_app.vars | default({})).kubeplay_pod_name | default(''))
+      }}
     _kubeplay_pod_manifest_path: >-
       {{
         kubeplay_pod_manifest_path

--- a/roles/podman_systemd/README.md
+++ b/roles/podman_systemd/README.md
@@ -1,0 +1,6 @@
+# lit.foundational.podman_systemd
+
+Manage persistent Podman kube services through Quadlet and systemd.
+
+The role renders a `.kube` Quadlet unit, reloads systemd, and can start,
+restart, stop, enable, disable, or remove the generated service.

--- a/roles/podman_systemd/defaults/main.yml
+++ b/roles/podman_systemd/defaults/main.yml
@@ -11,7 +11,12 @@ podman_systemd_unit_name: ""
 podman_systemd_description: "Podman kube service {{ podman_systemd_unit_name }}"
 podman_systemd_manifest_path: ""
 podman_systemd_scope: "system"
-podman_systemd_quadlet_dir: "{{ '/etc/containers/systemd' if podman_systemd_scope == 'system' else ansible_env.HOME ~ '/.config/containers/systemd' }}"
+podman_systemd_quadlet_dir: >-
+  {{
+    '/etc/containers/systemd'
+    if podman_systemd_scope == 'system'
+    else ansible_env.HOME ~ '/.config/containers/systemd'
+  }}
 podman_systemd_quadlet_path: "{{ podman_systemd_quadlet_dir }}/{{ podman_systemd_unit_name }}.kube"
 podman_systemd_service_name: "{{ podman_systemd_unit_name }}.service"
 podman_systemd_enabled: true

--- a/roles/podman_systemd/defaults/main.yml
+++ b/roles/podman_systemd/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+podman_systemd_action: "present"
+podman_systemd_allowed_actions:
+  - present
+  - started
+  - restarted
+  - stopped
+  - absent
+
+podman_systemd_unit_name: ""
+podman_systemd_description: "Podman kube service {{ podman_systemd_unit_name }}"
+podman_systemd_manifest_path: ""
+podman_systemd_scope: "system"
+podman_systemd_quadlet_dir: "{{ '/etc/containers/systemd' if podman_systemd_scope == 'system' else ansible_env.HOME ~ '/.config/containers/systemd' }}"
+podman_systemd_quadlet_path: "{{ podman_systemd_quadlet_dir }}/{{ podman_systemd_unit_name }}.kube"
+podman_systemd_service_name: "{{ podman_systemd_unit_name }}.service"
+podman_systemd_enabled: true
+podman_systemd_state: "started"
+podman_systemd_remove_quadlet: true
+podman_systemd_install_wanted_by: "multi-user.target"
+podman_systemd_after:
+  - network-online.target
+podman_systemd_wants:
+  - network-online.target

--- a/roles/podman_systemd/meta/main.yml
+++ b/roles/podman_systemd/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: podman_systemd
+  namespace: lit
+  author: Rene Osorio
+  description: Manage persistent Podman kube services through Quadlet and systemd.
+  company: Lightning IT
+  license: MIT
+  min_ansible_version: "2.18"
+
+  platforms:
+    - name: EL
+      versions:
+        - "9"
+
+  galaxy_tags:
+    - modulix
+    - podman
+    - systemd
+    - quadlet
+
+dependencies: []

--- a/roles/podman_systemd/tasks/assert.yml
+++ b/roles/podman_systemd/tasks/assert.yml
@@ -1,0 +1,22 @@
+---
+- name: Validate podman_systemd variables
+  ansible.builtin.assert:
+    that:
+      - podman_systemd_action in podman_systemd_allowed_actions
+      - podman_systemd_allowed_actions is sequence
+      - podman_systemd_allowed_actions is not string
+      - podman_systemd_unit_name | default('', true) | trim | length > 0
+      - podman_systemd_description | default('', true) | trim | length > 0
+      - podman_systemd_manifest_path | default('', true) | trim | length > 0
+      - podman_systemd_scope in ['system', 'user']
+      - podman_systemd_quadlet_dir | default('', true) | trim | length > 0
+      - podman_systemd_quadlet_path | default('', true) | trim | length > 0
+      - podman_systemd_service_name | default('', true) | trim | length > 0
+      - podman_systemd_enabled is boolean
+      - podman_systemd_remove_quadlet is boolean
+      - podman_systemd_after is sequence
+      - podman_systemd_after is not string
+      - podman_systemd_wants is sequence
+      - podman_systemd_wants is not string
+    fail_msg: "podman_systemd variables are missing or invalid."
+  tags: always

--- a/roles/podman_systemd/tasks/main.yml
+++ b/roles/podman_systemd/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Ensure Quadlet directory exists
+  ansible.builtin.file:
+    path: "{{ podman_systemd_quadlet_dir }}"
+    state: directory
+    mode: "0755"
+  when: podman_systemd_action != 'absent'
+  tags:
+    - podman_systemd
+
+- name: Render Podman kube Quadlet unit
+  ansible.builtin.template:
+    src: kube.quadlet.j2
+    dest: "{{ podman_systemd_quadlet_path }}"
+    mode: "0644"
+  register: podman_systemd_quadlet_render
+  when: podman_systemd_action != 'absent'
+  tags:
+    - podman_systemd
+
+- name: Reload systemd for Podman kube service
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: "{{ podman_systemd_scope }}"
+  when:
+    - podman_systemd_action != 'absent'
+    - podman_systemd_scope == 'system'
+  tags:
+    - podman_systemd
+
+- name: Reload user systemd for Podman kube service
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: user
+  when:
+    - podman_systemd_action != 'absent'
+    - podman_systemd_scope == 'user'
+  tags:
+    - podman_systemd
+
+- name: Manage Podman kube service state
+  ansible.builtin.systemd:
+    name: "{{ podman_systemd_service_name }}"
+    state: "{{ 'started' if podman_systemd_action == 'present' else podman_systemd_action }}"
+    enabled: "{{ podman_systemd_enabled }}"
+    scope: "{{ podman_systemd_scope }}"
+  when: podman_systemd_action in ['present', 'started', 'restarted', 'stopped']
+  tags:
+    - podman_systemd
+
+- name: Stop and disable Podman kube service
+  ansible.builtin.systemd:
+    name: "{{ podman_systemd_service_name }}"
+    state: stopped
+    enabled: false
+    scope: "{{ podman_systemd_scope }}"
+  failed_when: false
+  when: podman_systemd_action == 'absent'
+  tags:
+    - podman_systemd
+
+- name: Remove Podman kube Quadlet unit
+  ansible.builtin.file:
+    path: "{{ podman_systemd_quadlet_path }}"
+    state: absent
+  when:
+    - podman_systemd_action == 'absent'
+    - podman_systemd_remove_quadlet | bool
+  tags:
+    - podman_systemd
+
+- name: Reload systemd after Podman kube service removal
+  ansible.builtin.systemd:
+    daemon_reload: true
+    scope: "{{ podman_systemd_scope }}"
+  when: podman_systemd_action == 'absent'
+  tags:
+    - podman_systemd

--- a/roles/podman_systemd/templates/kube.quadlet.j2
+++ b/roles/podman_systemd/templates/kube.quadlet.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description={{ podman_systemd_description }}
+{% if podman_systemd_after | length > 0 %}
+After={{ podman_systemd_after | join(' ') }}
+{% endif %}
+{% if podman_systemd_wants | length > 0 %}
+Wants={{ podman_systemd_wants | join(' ') }}
+{% endif %}
+
+[Kube]
+Yaml={{ podman_systemd_manifest_path }}
+
+[Install]
+WantedBy={{ podman_systemd_install_wanted_by }}

--- a/roles/secret_backend/README.md
+++ b/roles/secret_backend/README.md
@@ -1,0 +1,10 @@
+# secret_backend
+
+Normalizes secret backend configuration into a reusable context fact.
+
+Supported backends:
+
+- `hashicorp_vault`
+- `ansible_vault`
+
+The default output fact is `secret_backend_context`.

--- a/roles/secret_backend/defaults/main.yml
+++ b/roles/secret_backend/defaults/main.yml
@@ -6,8 +6,20 @@ secret_backend_allowed_backends:
   - ansible_vault
 
 secret_backend_vault_addr: "{{ vault_addr | default(hc_vault_addr | default('', true), true) }}"
-secret_backend_vault_validate_certs: "{{ vault_validate_certs | default(hc_vault_validate_certs | default(true, true), true) }}"
-secret_backend_vault_token: "{{ vault_token | default(hc_vault_token | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true), true) }}"
+secret_backend_vault_validate_certs: >-
+  {{
+    vault_validate_certs
+    | default(hc_vault_validate_certs | default(true, true), true)
+  }}
+secret_backend_vault_token: >-
+  {{
+    vault_token
+    | default(
+        hc_vault_token
+        | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true),
+        true
+      )
+  }}
 secret_backend_vault_role_id: "{{ vault_role_id | default(hc_vault_role_id | default('', true), true) }}"
 secret_backend_vault_secret_id: "{{ vault_secret_id | default(hc_vault_secret_id | default('', true), true) }}"
 secret_backend_vault_auth_method: >-
@@ -16,5 +28,9 @@ secret_backend_vault_auth_method: >-
     if (secret_backend_vault_token | default('', true) | string | trim | length > 0)
     else 'approle'
   }}
-secret_backend_vault_kv_mount_point: "{{ vault_engine_mount_point | default(hc_vault_engine_mount_point | default('', true), true) }}"
+secret_backend_vault_kv_mount_point: >-
+  {{
+    vault_engine_mount_point
+    | default(hc_vault_engine_mount_point | default('', true), true)
+  }}
 secret_backend_result_fact: secret_backend_context

--- a/roles/secret_backend/defaults/main.yml
+++ b/roles/secret_backend/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+secret_backend_enabled: true
+secret_backend_name: hashicorp_vault
+secret_backend_allowed_backends:
+  - hashicorp_vault
+  - ansible_vault
+
+secret_backend_vault_addr: "{{ vault_addr | default(hc_vault_addr | default('', true), true) }}"
+secret_backend_vault_validate_certs: "{{ vault_validate_certs | default(hc_vault_validate_certs | default(true, true), true) }}"
+secret_backend_vault_token: "{{ vault_token | default(hc_vault_token | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true), true) }}"
+secret_backend_vault_role_id: "{{ vault_role_id | default(hc_vault_role_id | default('', true), true) }}"
+secret_backend_vault_secret_id: "{{ vault_secret_id | default(hc_vault_secret_id | default('', true), true) }}"
+secret_backend_vault_auth_method: >-
+  {{
+    'token'
+    if (secret_backend_vault_token | default('', true) | string | trim | length > 0)
+    else 'approle'
+  }}
+secret_backend_vault_kv_mount_point: "{{ vault_engine_mount_point | default(hc_vault_engine_mount_point | default('', true), true) }}"
+secret_backend_result_fact: secret_backend_context

--- a/roles/secret_backend/meta/main.yml
+++ b/roles/secret_backend/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Lightning IT
+  description: Normalize generic secret backend configuration.
+  license: MIT
+  min_ansible_version: "2.15"
+dependencies: []

--- a/roles/secret_backend/tasks/assert.yml
+++ b/roles/secret_backend/tasks/assert.yml
@@ -1,0 +1,30 @@
+---
+- name: Validate secret backend variables
+  ansible.builtin.assert:
+    that:
+      - secret_backend_enabled is boolean
+      - secret_backend_name in secret_backend_allowed_backends
+      - secret_backend_allowed_backends is sequence
+      - secret_backend_allowed_backends is not string
+    fail_msg: "Secret backend variables are missing or invalid."
+  tags: always
+
+- name: Validate HashiCorp Vault backend variables
+  ansible.builtin.assert:
+    that:
+      - secret_backend_vault_addr | default('', true) | trim | length > 0
+      - secret_backend_vault_kv_mount_point | default('', true) | trim | length > 0
+      - secret_backend_vault_validate_certs is boolean
+      - secret_backend_vault_auth_method in ['token', 'approle']
+      - >-
+        (secret_backend_vault_auth_method == 'token'
+         and secret_backend_vault_token | default('', true) | trim | length > 0)
+        or
+        (secret_backend_vault_auth_method == 'approle'
+         and secret_backend_vault_role_id | default('', true) | trim | length > 0
+         and secret_backend_vault_secret_id | default('', true) | trim | length > 0)
+    fail_msg: "HashiCorp Vault backend requires address, KV mount, and token or AppRole credentials."
+  when:
+    - secret_backend_enabled | bool
+    - secret_backend_name == 'hashicorp_vault'
+  tags: always

--- a/roles/secret_backend/tasks/main.yml
+++ b/roles/secret_backend/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Record disabled secret backend context
   ansible.builtin.set_fact:
-    "{{ secret_backend_result_fact }}":
+    secret_backend_context:
       enabled: false
       backend: "{{ secret_backend_name }}"
   changed_when: false
@@ -14,7 +14,7 @@
 
 - name: Record HashiCorp Vault secret backend context
   ansible.builtin.set_fact:
-    "{{ secret_backend_result_fact }}":
+    secret_backend_context:
       enabled: true
       backend: hashicorp_vault
       vault_addr: "{{ secret_backend_vault_addr | string | trim }}"
@@ -32,7 +32,7 @@
 
 - name: Record Ansible Vault secret backend context
   ansible.builtin.set_fact:
-    "{{ secret_backend_result_fact }}":
+    secret_backend_context:
       enabled: true
       backend: ansible_vault
   changed_when: false

--- a/roles/secret_backend/tasks/main.yml
+++ b/roles/secret_backend/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Record disabled secret backend context
+  ansible.builtin.set_fact:
+    "{{ secret_backend_result_fact }}":
+      enabled: false
+      backend: "{{ secret_backend_name }}"
+  changed_when: false
+  when: not secret_backend_enabled | bool
+  tags: always
+
+- name: Record HashiCorp Vault secret backend context
+  ansible.builtin.set_fact:
+    "{{ secret_backend_result_fact }}":
+      enabled: true
+      backend: hashicorp_vault
+      vault_addr: "{{ secret_backend_vault_addr | string | trim }}"
+      vault_validate_certs: "{{ secret_backend_vault_validate_certs | bool }}"
+      vault_auth_method: "{{ secret_backend_vault_auth_method }}"
+      vault_token: "{{ secret_backend_vault_token | string | trim }}"
+      vault_role_id: "{{ secret_backend_vault_role_id | string | trim }}"
+      vault_secret_id: "{{ secret_backend_vault_secret_id | string | trim }}"
+      vault_kv_mount_point: "{{ secret_backend_vault_kv_mount_point | string | trim }}"
+  changed_when: false
+  when:
+    - secret_backend_enabled | bool
+    - secret_backend_name == 'hashicorp_vault'
+  no_log: true
+
+- name: Record Ansible Vault secret backend context
+  ansible.builtin.set_fact:
+    "{{ secret_backend_result_fact }}":
+      enabled: true
+      backend: ansible_vault
+  changed_when: false
+  when:
+    - secret_backend_enabled | bool
+    - secret_backend_name == 'ansible_vault'

--- a/roles/secret_kv/README.md
+++ b/roles/secret_kv/README.md
@@ -1,0 +1,10 @@
+# secret_kv
+
+Reads or writes generic KV secrets.
+
+Currently supported backend:
+
+- HashiCorp Vault KV v2
+
+For Ansible Vault, decrypt values before calling application roles; this role
+does not edit vault-encrypted files.

--- a/roles/secret_kv/defaults/main.yml
+++ b/roles/secret_kv/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+secret_kv_enabled: true
+secret_kv_backend: hashicorp_vault
+secret_kv_action: read
+secret_kv_allowed_actions:
+  - read
+  - write
+  - upsert
+
+secret_kv_vault_addr: "{{ secret_backend_context.vault_addr | default(vault_addr | default(hc_vault_addr | default('', true), true), true) }}"
+secret_kv_vault_validate_certs: "{{ secret_backend_context.vault_validate_certs | default(vault_validate_certs | default(hc_vault_validate_certs | default(true, true), true), true) }}"
+secret_kv_vault_auth_method: "{{ secret_backend_context.vault_auth_method | default(hc_vault_auth_method | default('token', true), true) }}"
+secret_kv_vault_token: "{{ secret_backend_context.vault_token | default(vault_token | default(hc_vault_token | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true), true), true) }}"
+secret_kv_vault_role_id: "{{ secret_backend_context.vault_role_id | default(vault_role_id | default(hc_vault_role_id | default('', true), true), true) }}"
+secret_kv_vault_secret_id: "{{ secret_backend_context.vault_secret_id | default(vault_secret_id | default(hc_vault_secret_id | default('', true), true), true) }}"
+secret_kv_vault_mount_point: "{{ secret_backend_context.vault_kv_mount_point | default(vault_engine_mount_point | default(hc_vault_engine_mount_point | default('', true), true), true) }}"
+secret_kv_path: ""
+secret_kv_data: {}
+secret_kv_merge_existing: true
+secret_kv_result_fact: secret_kv_result

--- a/roles/secret_kv/defaults/main.yml
+++ b/roles/secret_kv/defaults/main.yml
@@ -7,13 +7,57 @@ secret_kv_allowed_actions:
   - write
   - upsert
 
-secret_kv_vault_addr: "{{ secret_backend_context.vault_addr | default(vault_addr | default(hc_vault_addr | default('', true), true), true) }}"
-secret_kv_vault_validate_certs: "{{ secret_backend_context.vault_validate_certs | default(vault_validate_certs | default(hc_vault_validate_certs | default(true, true), true), true) }}"
-secret_kv_vault_auth_method: "{{ secret_backend_context.vault_auth_method | default(hc_vault_auth_method | default('token', true), true) }}"
-secret_kv_vault_token: "{{ secret_backend_context.vault_token | default(vault_token | default(hc_vault_token | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true), true), true) }}"
-secret_kv_vault_role_id: "{{ secret_backend_context.vault_role_id | default(vault_role_id | default(hc_vault_role_id | default('', true), true), true) }}"
-secret_kv_vault_secret_id: "{{ secret_backend_context.vault_secret_id | default(vault_secret_id | default(hc_vault_secret_id | default('', true), true), true) }}"
-secret_kv_vault_mount_point: "{{ secret_backend_context.vault_kv_mount_point | default(vault_engine_mount_point | default(hc_vault_engine_mount_point | default('', true), true), true) }}"
+secret_kv_vault_addr: >-
+  {{
+    secret_backend_context.vault_addr
+    | default(vault_addr | default(hc_vault_addr | default('', true), true), true)
+  }}
+secret_kv_vault_validate_certs: >-
+  {{
+    secret_backend_context.vault_validate_certs
+    | default(
+        vault_validate_certs
+        | default(hc_vault_validate_certs | default(true, true), true),
+        true
+      )
+  }}
+secret_kv_vault_auth_method: >-
+  {{
+    secret_backend_context.vault_auth_method
+    | default(hc_vault_auth_method | default('token', true), true)
+  }}
+secret_kv_vault_token: >-
+  {{
+    secret_backend_context.vault_token
+    | default(
+        vault_token
+        | default(
+            hc_vault_token
+            | default(lookup('ansible.builtin.env', 'VAULT_TOKEN') | default('', true), true),
+            true
+          ),
+        true
+      )
+  }}
+secret_kv_vault_role_id: >-
+  {{
+    secret_backend_context.vault_role_id
+    | default(vault_role_id | default(hc_vault_role_id | default('', true), true), true)
+  }}
+secret_kv_vault_secret_id: >-
+  {{
+    secret_backend_context.vault_secret_id
+    | default(vault_secret_id | default(hc_vault_secret_id | default('', true), true), true)
+  }}
+secret_kv_vault_mount_point: >-
+  {{
+    secret_backend_context.vault_kv_mount_point
+    | default(
+        vault_engine_mount_point
+        | default(hc_vault_engine_mount_point | default('', true), true),
+        true
+      )
+  }}
 secret_kv_path: ""
 secret_kv_data: {}
 secret_kv_merge_existing: true

--- a/roles/secret_kv/meta/main.yml
+++ b/roles/secret_kv/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Lightning IT
+  description: Generic secret KV read/write helper.
+  license: MIT
+  min_ansible_version: "2.15"
+dependencies: []

--- a/roles/secret_kv/tasks/assert.yml
+++ b/roles/secret_kv/tasks/assert.yml
@@ -1,0 +1,34 @@
+---
+- name: Validate secret KV variables
+  ansible.builtin.assert:
+    that:
+      - secret_kv_enabled is boolean
+      - secret_kv_backend in ['hashicorp_vault', 'ansible_vault']
+      - secret_kv_action in secret_kv_allowed_actions
+      - secret_kv_allowed_actions is sequence
+      - secret_kv_allowed_actions is not string
+      - secret_kv_path | default('', true) | trim | length > 0
+      - secret_kv_data is mapping
+      - secret_kv_merge_existing is boolean
+    fail_msg: "Secret KV variables are missing or invalid."
+  tags: always
+
+- name: Validate HashiCorp Vault KV variables
+  ansible.builtin.assert:
+    that:
+      - secret_kv_vault_addr | default('', true) | trim | length > 0
+      - secret_kv_vault_mount_point | default('', true) | trim | length > 0
+      - secret_kv_vault_validate_certs is boolean
+      - secret_kv_vault_auth_method in ['token', 'approle']
+      - >-
+        (secret_kv_vault_auth_method == 'token'
+         and secret_kv_vault_token | default('', true) | trim | length > 0)
+        or
+        (secret_kv_vault_auth_method == 'approle'
+         and secret_kv_vault_role_id | default('', true) | trim | length > 0
+         and secret_kv_vault_secret_id | default('', true) | trim | length > 0)
+    fail_msg: "HashiCorp Vault KV requires address, mount, and token or AppRole credentials."
+  when:
+    - secret_kv_enabled | bool
+    - secret_kv_backend == 'hashicorp_vault'
+  tags: always

--- a/roles/secret_kv/tasks/main.yml
+++ b/roles/secret_kv/tasks/main.yml
@@ -21,9 +21,18 @@
   community.hashi_vault.vault_kv2_get:
     url: "{{ secret_kv_vault_addr }}"
     auth_method: "{{ secret_kv_vault_auth_method }}"
-    token: "{{ secret_kv_vault_token if (secret_kv_vault_token | default('', true) | trim | length > 0) else omit }}"
-    role_id: "{{ secret_kv_vault_role_id if (secret_kv_vault_role_id | default('', true) | trim | length > 0) else omit }}"
-    secret_id: "{{ secret_kv_vault_secret_id if (secret_kv_vault_secret_id | default('', true) | trim | length > 0) else omit }}"
+    token: >-
+      {{ secret_kv_vault_token
+         if (secret_kv_vault_token | default('', true) | trim | length > 0)
+         else omit }}
+    role_id: >-
+      {{ secret_kv_vault_role_id
+         if (secret_kv_vault_role_id | default('', true) | trim | length > 0)
+         else omit }}
+    secret_id: >-
+      {{ secret_kv_vault_secret_id
+         if (secret_kv_vault_secret_id | default('', true) | trim | length > 0)
+         else omit }}
     validate_certs: "{{ secret_kv_vault_validate_certs | bool }}"
     engine_mount_point: "{{ secret_kv_vault_mount_point }}"
     path: "{{ secret_kv_path }}"
@@ -41,9 +50,18 @@
   community.hashi_vault.vault_kv2_write:
     url: "{{ secret_kv_vault_addr }}"
     auth_method: "{{ secret_kv_vault_auth_method }}"
-    token: "{{ secret_kv_vault_token if (secret_kv_vault_token | default('', true) | trim | length > 0) else omit }}"
-    role_id: "{{ secret_kv_vault_role_id if (secret_kv_vault_role_id | default('', true) | trim | length > 0) else omit }}"
-    secret_id: "{{ secret_kv_vault_secret_id if (secret_kv_vault_secret_id | default('', true) | trim | length > 0) else omit }}"
+    token: >-
+      {{ secret_kv_vault_token
+         if (secret_kv_vault_token | default('', true) | trim | length > 0)
+         else omit }}
+    role_id: >-
+      {{ secret_kv_vault_role_id
+         if (secret_kv_vault_role_id | default('', true) | trim | length > 0)
+         else omit }}
+    secret_id: >-
+      {{ secret_kv_vault_secret_id
+         if (secret_kv_vault_secret_id | default('', true) | trim | length > 0)
+         else omit }}
     validate_certs: "{{ secret_kv_vault_validate_certs | bool }}"
     engine_mount_point: "{{ secret_kv_vault_mount_point }}"
     path: "{{ secret_kv_path }}"
@@ -67,7 +85,7 @@
 
 - name: Record secret KV result
   ansible.builtin.set_fact:
-    "{{ secret_kv_result_fact }}":
+    secret_kv_result:
       backend: "{{ secret_kv_backend }}"
       action: "{{ secret_kv_action }}"
       path: "{{ secret_kv_path }}"

--- a/roles/secret_kv/tasks/main.yml
+++ b/roles/secret_kv/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Skip secret KV action when disabled
+  ansible.builtin.debug:
+    msg: "Secret KV action skipped because secret_kv_enabled=false."
+  changed_when: false
+  when: not secret_kv_enabled | bool
+  tags: always
+
+- name: Fail for Ansible Vault KV operations
+  ansible.builtin.fail:
+    msg: "secret_kv does not read or write Ansible Vault files; pass decrypted variables directly."
+  when:
+    - secret_kv_enabled | bool
+    - secret_kv_backend == 'ansible_vault'
+
+- name: Read HashiCorp Vault KV secret
+  community.hashi_vault.vault_kv2_get:
+    url: "{{ secret_kv_vault_addr }}"
+    auth_method: "{{ secret_kv_vault_auth_method }}"
+    token: "{{ secret_kv_vault_token if (secret_kv_vault_token | default('', true) | trim | length > 0) else omit }}"
+    role_id: "{{ secret_kv_vault_role_id if (secret_kv_vault_role_id | default('', true) | trim | length > 0) else omit }}"
+    secret_id: "{{ secret_kv_vault_secret_id if (secret_kv_vault_secret_id | default('', true) | trim | length > 0) else omit }}"
+    validate_certs: "{{ secret_kv_vault_validate_certs | bool }}"
+    engine_mount_point: "{{ secret_kv_vault_mount_point }}"
+    path: "{{ secret_kv_path }}"
+  register: secret_kv_read
+  delegate_to: localhost
+  become: false
+  failed_when: false
+  when:
+    - secret_kv_enabled | bool
+    - secret_kv_backend == 'hashicorp_vault'
+    - secret_kv_action in ['read', 'upsert']
+  no_log: true
+
+- name: Write HashiCorp Vault KV secret
+  community.hashi_vault.vault_kv2_write:
+    url: "{{ secret_kv_vault_addr }}"
+    auth_method: "{{ secret_kv_vault_auth_method }}"
+    token: "{{ secret_kv_vault_token if (secret_kv_vault_token | default('', true) | trim | length > 0) else omit }}"
+    role_id: "{{ secret_kv_vault_role_id if (secret_kv_vault_role_id | default('', true) | trim | length > 0) else omit }}"
+    secret_id: "{{ secret_kv_vault_secret_id if (secret_kv_vault_secret_id | default('', true) | trim | length > 0) else omit }}"
+    validate_certs: "{{ secret_kv_vault_validate_certs | bool }}"
+    engine_mount_point: "{{ secret_kv_vault_mount_point }}"
+    path: "{{ secret_kv_path }}"
+    data: >-
+      {{
+        (
+          (secret_kv_read.data.data | default({}))
+          if (secret_kv_action == 'upsert' and secret_kv_merge_existing | bool)
+          else {}
+        )
+        | combine(secret_kv_data, recursive=true)
+      }}
+  register: secret_kv_write
+  delegate_to: localhost
+  become: false
+  when:
+    - secret_kv_enabled | bool
+    - secret_kv_backend == 'hashicorp_vault'
+    - secret_kv_action in ['write', 'upsert']
+  no_log: true
+
+- name: Record secret KV result
+  ansible.builtin.set_fact:
+    "{{ secret_kv_result_fact }}":
+      backend: "{{ secret_kv_backend }}"
+      action: "{{ secret_kv_action }}"
+      path: "{{ secret_kv_path }}"
+      exists: "{{ not (secret_kv_read.failed | default(false) | bool) if secret_kv_read is defined else omit }}"
+      secret: "{{ secret_kv_read.data.data | default({}) if secret_kv_read is defined else omit }}"
+      changed: "{{ secret_kv_write.changed | default(false) if secret_kv_write is defined else false }}"
+  changed_when: false
+  when: secret_kv_enabled | bool
+  no_log: true

--- a/roles/tls_assets/README.md
+++ b/roles/tls_assets/README.md
@@ -1,0 +1,13 @@
+# tls_assets
+
+Stages TLS certificate, key, and CA bundle files on a managed host.
+
+Supported sources:
+
+- `customer_files`: copy controller-side files or write inline PEM content.
+- `vault_pki`: issue certificates through `lit.foundational.vault_pki_cert`
+  and stage the issued cert/key/CA files.
+
+The role is intentionally service-generic. Application roles should map their
+service names and installer/runtime variables to `tls_assets_services`,
+`tls_assets_target_files`, and `tls_assets_customer_files`.

--- a/roles/tls_assets/defaults/main.yml
+++ b/roles/tls_assets/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+tls_assets_enabled: true
+tls_assets_source: customer_files
+tls_assets_allowed_sources:
+  - customer_files
+  - vault_pki
+
+tls_assets_dir: "/etc/tls-assets"
+tls_assets_owner: root
+tls_assets_group: root
+tls_assets_dir_mode: "0755"
+tls_assets_cert_mode: "0644"
+tls_assets_key_mode: "0600"
+tls_assets_ca_mode: "0644"
+
+tls_assets_services: []
+tls_assets_target_files: {}
+tls_assets_customer_files: {}
+tls_assets_ca_cert_path: "{{ tls_assets_dir }}/ca.crt"
+
+tls_assets_vault_pki_addr: "{{ vault_pki_cert_addr | default('', true) }}"
+tls_assets_vault_pki_auth_method: "{{ vault_pki_cert_auth_method | default('token', true) }}"
+tls_assets_vault_pki_token: "{{ vault_pki_cert_token | default('', true) }}"
+tls_assets_vault_pki_role_id: "{{ vault_pki_cert_role_id | default('', true) }}"
+tls_assets_vault_pki_secret_id: "{{ vault_pki_cert_secret_id | default('', true) }}"
+tls_assets_vault_pki_approle_path: ""
+tls_assets_vault_pki_approle_kv_mount_point: "{{ tls_assets_vault_pki_kv_mount_point | default('', true) }}"
+tls_assets_vault_pki_approle_read_token: "{{ tls_assets_vault_pki_token }}"
+tls_assets_vault_pki_validate_certs: "{{ vault_pki_cert_validate_certs | default(true, true) }}"
+tls_assets_vault_pki_mount_point: "{{ vault_pki_cert_mount_point | default('', true) }}"
+tls_assets_vault_pki_services: {}
+tls_assets_vault_pki_ttl: "{{ vault_pki_cert_ttl | default('', true) }}"
+tls_assets_vault_pki_format: pem
+tls_assets_vault_pki_private_key_format: pkcs8
+tls_assets_vault_pki_require_shared_ca: true
+tls_assets_vault_pki_require_trust_anchor: true
+tls_assets_vault_pki_read_issuer: true
+
+tls_assets_result_fact: tls_assets_result

--- a/roles/tls_assets/meta/main.yml
+++ b/roles/tls_assets/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Lightning IT
+  description: Stage generic TLS assets from files, inline content, or Vault PKI.
+  license: MIT
+  min_ansible_version: "2.15"
+dependencies: []

--- a/roles/tls_assets/tasks/assert.yml
+++ b/roles/tls_assets/tasks/assert.yml
@@ -1,0 +1,85 @@
+---
+- name: Validate TLS asset variables
+  ansible.builtin.assert:
+    that:
+      - tls_assets_enabled is boolean
+      - tls_assets_source in tls_assets_allowed_sources
+      - tls_assets_dir | default('', true) | trim | length > 0
+      - tls_assets_dir.startswith('/')
+      - tls_assets_owner | default('', true) | string | trim | length > 0
+      - tls_assets_group | default('', true) | string | trim | length > 0
+      - tls_assets_services is sequence
+      - tls_assets_services is not string
+      - tls_assets_target_files is mapping
+      - tls_assets_customer_files is mapping
+      - tls_assets_ca_cert_path | default('', true) | trim | length > 0
+      - tls_assets_ca_cert_path.startswith('/')
+    fail_msg: "TLS asset variables are missing or invalid."
+  tags: always
+
+- name: Validate TLS asset service targets
+  ansible.builtin.assert:
+    that:
+      - item | default('', true) | trim | length > 0
+      - tls_assets_target_files[item] is mapping
+      - tls_assets_target_files[item].cert_path | default('', true) | trim | length > 0
+      - tls_assets_target_files[item].cert_path.startswith('/')
+      - tls_assets_target_files[item].key_path | default('', true) | trim | length > 0
+      - tls_assets_target_files[item].key_path.startswith('/')
+    fail_msg: "Each TLS asset service requires absolute cert_path and key_path targets."
+  loop: "{{ tls_assets_services }}"
+  when: tls_assets_enabled | bool
+  tags: always
+
+- name: Validate customer TLS asset inputs
+  ansible.builtin.assert:
+    that:
+      - tls_assets_customer_files[item] is mapping
+      - >-
+        (tls_assets_customer_files[item].cert_src | default('', true) | trim | length > 0)
+        or
+        (tls_assets_customer_files[item].cert_content | default('', true) | trim | length > 0)
+      - >-
+        (tls_assets_customer_files[item].key_src | default('', true) | trim | length > 0)
+        or
+        (tls_assets_customer_files[item].key_content | default('', true) | trim | length > 0)
+      - >-
+        (tls_assets_customer_files[item].cert_src | default('', true) | trim | length == 0)
+        or tls_assets_customer_files[item].cert_src.startswith('/')
+      - >-
+        (tls_assets_customer_files[item].key_src | default('', true) | trim | length == 0)
+        or tls_assets_customer_files[item].key_src.startswith('/')
+    fail_msg: "Customer TLS service inputs require cert/key source paths or inline content."
+  loop: "{{ tls_assets_services }}"
+  when:
+    - tls_assets_enabled | bool
+    - tls_assets_source == 'customer_files'
+  tags: always
+
+- name: Validate customer TLS CA input
+  ansible.builtin.assert:
+    that:
+      - >-
+        (tls_assets_customer_files.ca_cert_src | default('', true) | trim | length > 0)
+        or
+        (tls_assets_customer_files.ca_cert_content | default('', true) | trim | length > 0)
+      - >-
+        (tls_assets_customer_files.ca_cert_src | default('', true) | trim | length == 0)
+        or tls_assets_customer_files.ca_cert_src.startswith('/')
+    fail_msg: "Customer TLS CA input requires ca_cert_src or ca_cert_content."
+  when:
+    - tls_assets_enabled | bool
+    - tls_assets_source == 'customer_files'
+  tags: always
+
+- name: Validate Vault PKI AppRole KV lookup inputs
+  ansible.builtin.assert:
+    that:
+      - tls_assets_vault_pki_approle_kv_mount_point | default('', true) | trim | length > 0
+      - tls_assets_vault_pki_approle_read_token | default('', true) | trim | length > 0
+    fail_msg: "Vault PKI AppRole lookup requires KV mount point and read token."
+  when:
+    - tls_assets_enabled | bool
+    - tls_assets_source == 'vault_pki'
+    - tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+  tags: always

--- a/roles/tls_assets/tasks/main.yml
+++ b/roles/tls_assets/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Skip TLS asset staging when disabled
+  ansible.builtin.debug:
+    msg: "TLS asset staging skipped because tls_assets_enabled=false."
+  changed_when: false
+  when: not tls_assets_enabled | bool
+  tags: always
+
+- name: Stage TLS assets
+  when: tls_assets_enabled | bool
+  block:
+    - name: Ensure TLS asset directory exists
+      ansible.builtin.file:
+        path: "{{ tls_assets_dir }}"
+        state: directory
+        owner: "{{ tls_assets_owner }}"
+        group: "{{ tls_assets_group }}"
+        mode: "{{ tls_assets_dir_mode }}"
+
+    - name: Stage customer TLS assets
+      ansible.builtin.import_tasks: stage_customer_files.yml
+      when: tls_assets_source == 'customer_files'
+
+    - name: Generate and stage Vault PKI TLS assets
+      ansible.builtin.import_tasks: stage_vault_pki.yml
+      when: tls_assets_source == 'vault_pki'
+
+    - name: Record staged TLS asset result
+      ansible.builtin.set_fact:
+        "{{ tls_assets_result_fact }}":
+          services: "{{ tls_assets_services }}"
+          target_files: "{{ tls_assets_target_files }}"
+          ca_cert_path: "{{ tls_assets_ca_cert_path }}"
+      changed_when: false

--- a/roles/tls_assets/tasks/main.yml
+++ b/roles/tls_assets/tasks/main.yml
@@ -31,7 +31,7 @@
 
     - name: Record staged TLS asset result
       ansible.builtin.set_fact:
-        "{{ tls_assets_result_fact }}":
+        tls_assets_result:
           services: "{{ tls_assets_services }}"
           target_files: "{{ tls_assets_target_files }}"
           ca_cert_path: "{{ tls_assets_ca_cert_path }}"

--- a/roles/tls_assets/tasks/stage_customer_files.yml
+++ b/roles/tls_assets/tasks/stage_customer_files.yml
@@ -1,0 +1,84 @@
+---
+- name: Copy customer TLS service certificates to target
+  ansible.builtin.copy:
+    src: "{{ tls_assets_customer_files[item].cert_src }}"
+    dest: "{{ tls_assets_target_files[item].cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_cert_mode }}"
+  loop: "{{ tls_assets_services }}"
+  when: tls_assets_customer_files[item].cert_src | default('', true) | trim | length > 0
+
+- name: Write customer TLS service certificates to target from inline content
+  ansible.builtin.copy:
+    content: >-
+      {{
+        tls_assets_customer_files[item].cert_content
+        | default('', true)
+        | string
+        | replace('\\n', '\n')
+      }}
+    dest: "{{ tls_assets_target_files[item].cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_cert_mode }}"
+  loop: "{{ tls_assets_services }}"
+  when:
+    - tls_assets_customer_files[item].cert_src | default('', true) | trim | length == 0
+    - tls_assets_customer_files[item].cert_content | default('', true) | trim | length > 0
+
+- name: Copy customer TLS service keys to target
+  ansible.builtin.copy:
+    src: "{{ tls_assets_customer_files[item].key_src }}"
+    dest: "{{ tls_assets_target_files[item].key_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_key_mode }}"
+  loop: "{{ tls_assets_services }}"
+  when: tls_assets_customer_files[item].key_src | default('', true) | trim | length > 0
+  no_log: true
+
+- name: Write customer TLS service keys to target from inline content
+  ansible.builtin.copy:
+    content: >-
+      {{
+        tls_assets_customer_files[item].key_content
+        | default('', true)
+        | string
+        | replace('\\n', '\n')
+      }}
+    dest: "{{ tls_assets_target_files[item].key_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_key_mode }}"
+  loop: "{{ tls_assets_services }}"
+  when:
+    - tls_assets_customer_files[item].key_src | default('', true) | trim | length == 0
+    - tls_assets_customer_files[item].key_content | default('', true) | trim | length > 0
+  no_log: true
+
+- name: Copy customer CA certificate to target
+  ansible.builtin.copy:
+    src: "{{ tls_assets_customer_files.ca_cert_src }}"
+    dest: "{{ tls_assets_ca_cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_ca_mode }}"
+  when: tls_assets_customer_files.ca_cert_src | default('', true) | trim | length > 0
+
+- name: Write customer CA certificate to target from inline content
+  ansible.builtin.copy:
+    content: >-
+      {{
+        tls_assets_customer_files.ca_cert_content
+        | default('', true)
+        | string
+        | replace('\\n', '\n')
+      }}
+    dest: "{{ tls_assets_ca_cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_ca_mode }}"
+  when:
+    - tls_assets_customer_files.ca_cert_src | default('', true) | trim | length == 0
+    - tls_assets_customer_files.ca_cert_content | default('', true) | trim | length > 0

--- a/roles/tls_assets/tasks/stage_vault_pki.yml
+++ b/roles/tls_assets/tasks/stage_vault_pki.yml
@@ -1,0 +1,181 @@
+---
+- name: Read Vault PKI AppRole credentials from KV
+  ansible.builtin.include_role:
+    name: lit.foundational.secret_kv
+  vars:
+    secret_kv_backend: hashicorp_vault
+    secret_kv_action: read
+    secret_kv_vault_addr: "{{ tls_assets_vault_pki_addr }}"
+    secret_kv_vault_auth_method: token
+    secret_kv_vault_token: "{{ tls_assets_vault_pki_approle_read_token }}"
+    secret_kv_vault_validate_certs: "{{ tls_assets_vault_pki_validate_certs }}"
+    secret_kv_vault_mount_point: "{{ tls_assets_vault_pki_approle_kv_mount_point }}"
+    secret_kv_path: "{{ tls_assets_vault_pki_approle_path }}"
+    secret_kv_result_fact: tls_assets_vault_pki_approle_secret
+  when: tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+  no_log: true
+
+- name: Compute effective Vault PKI auth inputs
+  ansible.builtin.set_fact:
+    tls_assets_vault_pki_role_id_effective: >-
+      {{
+        (
+          tls_assets_vault_pki_approle_secret.secret.role_id
+          if (
+            tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+            and tls_assets_vault_pki_approle_secret is defined
+            and tls_assets_vault_pki_approle_secret.secret is defined
+          )
+          else tls_assets_vault_pki_role_id
+        )
+        | string
+        | trim
+      }}
+    tls_assets_vault_pki_secret_id_effective: >-
+      {{
+        (
+          tls_assets_vault_pki_approle_secret.secret.secret_id
+          if (
+            tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+            and tls_assets_vault_pki_approle_secret is defined
+            and tls_assets_vault_pki_approle_secret.secret is defined
+          )
+          else tls_assets_vault_pki_secret_id
+        )
+        | string
+        | trim
+      }}
+    tls_assets_vault_pki_auth_method_effective: >-
+      {{
+        'approle'
+        if (
+          (
+            (
+              tls_assets_vault_pki_approle_secret.secret.role_id
+              if (
+                tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+                and tls_assets_vault_pki_approle_secret is defined
+                and tls_assets_vault_pki_approle_secret.secret is defined
+              )
+              else tls_assets_vault_pki_role_id
+            )
+            | string
+            | trim
+            | length
+          ) > 0
+          and
+          (
+            (
+              tls_assets_vault_pki_approle_secret.secret.secret_id
+              if (
+                tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+                and tls_assets_vault_pki_approle_secret is defined
+                and tls_assets_vault_pki_approle_secret.secret is defined
+              )
+              else tls_assets_vault_pki_secret_id
+            )
+            | string
+            | trim
+            | length
+          ) > 0
+        )
+        else tls_assets_vault_pki_auth_method
+      }}
+    tls_assets_vault_pki_token_effective: >-
+      {{
+        ''
+        if (
+          (
+            (
+              tls_assets_vault_pki_approle_secret.secret.role_id
+              if (
+                tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+                and tls_assets_vault_pki_approle_secret is defined
+                and tls_assets_vault_pki_approle_secret.secret is defined
+              )
+              else tls_assets_vault_pki_role_id
+            )
+            | string
+            | trim
+            | length
+          ) > 0
+          and
+          (
+            (
+              tls_assets_vault_pki_approle_secret.secret.secret_id
+              if (
+                tls_assets_vault_pki_approle_path | default('', true) | trim | length > 0
+                and tls_assets_vault_pki_approle_secret is defined
+                and tls_assets_vault_pki_approle_secret.secret is defined
+              )
+              else tls_assets_vault_pki_secret_id
+            )
+            | string
+            | trim
+            | length
+          ) > 0
+        )
+        else tls_assets_vault_pki_token
+      }}
+  changed_when: false
+  no_log: true
+
+- name: Generate Vault PKI certificates
+  ansible.builtin.include_role:
+    name: lit.foundational.vault_pki_cert
+  vars:
+    vault_pki_cert_addr: "{{ tls_assets_vault_pki_addr }}"
+    vault_pki_cert_auth_method: "{{ tls_assets_vault_pki_auth_method_effective }}"
+    vault_pki_cert_token: "{{ tls_assets_vault_pki_token_effective }}"
+    vault_pki_cert_role_id: "{{ tls_assets_vault_pki_role_id_effective }}"
+    vault_pki_cert_secret_id: "{{ tls_assets_vault_pki_secret_id_effective }}"
+    vault_pki_cert_validate_certs: "{{ tls_assets_vault_pki_validate_certs }}"
+    vault_pki_cert_mount_point: "{{ tls_assets_vault_pki_mount_point }}"
+    vault_pki_cert_services: "{{ tls_assets_vault_pki_services }}"
+    vault_pki_cert_service_names: "{{ tls_assets_services }}"
+    vault_pki_cert_ttl: "{{ tls_assets_vault_pki_ttl }}"
+    vault_pki_cert_format: "{{ tls_assets_vault_pki_format }}"
+    vault_pki_cert_private_key_format: "{{ tls_assets_vault_pki_private_key_format }}"
+    vault_pki_cert_require_shared_ca: "{{ tls_assets_vault_pki_require_shared_ca }}"
+    vault_pki_cert_require_trust_anchor: "{{ tls_assets_vault_pki_require_trust_anchor }}"
+    vault_pki_cert_read_issuer: "{{ tls_assets_vault_pki_read_issuer }}"
+
+- name: Copy Vault PKI service certificates to target
+  ansible.builtin.template:
+    src: pem_bundle.j2
+    dest: "{{ tls_assets_target_files[item.item].cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_cert_mode }}"
+  loop: "{{ vault_pki_cert_results.results | default([]) }}"
+  vars:
+    tls_assets_pem_entries: >-
+      {{
+        [item.data.data.certificate]
+        + (item.data.data.ca_chain | default([]))
+      }}
+  no_log: true
+
+- name: Copy Vault PKI service keys to target
+  ansible.builtin.template:
+    src: pem_bundle.j2
+    dest: "{{ tls_assets_target_files[item.item].key_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_key_mode }}"
+  loop: "{{ vault_pki_cert_results.results | default([]) }}"
+  vars:
+    tls_assets_pem_entries:
+      - "{{ item.data.data.private_key }}"
+  no_log: true
+
+- name: Copy shared Vault PKI CA bundle to target
+  ansible.builtin.template:
+    src: pem_bundle.j2
+    dest: "{{ tls_assets_ca_cert_path }}"
+    owner: "{{ tls_assets_owner }}"
+    group: "{{ tls_assets_group }}"
+    mode: "{{ tls_assets_ca_mode }}"
+  vars:
+    tls_assets_pem_entries: "{{ vault_pki_cert_ca_entries }}"
+  no_log: true

--- a/roles/tls_assets/templates/pem_bundle.j2
+++ b/roles/tls_assets/templates/pem_bundle.j2
@@ -1,0 +1,3 @@
+{% for pem_entry in tls_assets_pem_entries | default([]) %}
+{{ pem_entry | string | replace('\r', '') | replace('\\n', "\n") | trim }}
+{% endfor %}

--- a/roles/vault_pki_cert/README.md
+++ b/roles/vault_pki_cert/README.md
@@ -1,0 +1,11 @@
+# vault_pki_cert
+
+Issues one or more service certificates from HashiCorp Vault PKI.
+
+The role is service-generic. Each service entry defines `role_name`,
+`common_name`, `alt_names`, and `ip_sans`. Results are exposed as:
+
+- `vault_pki_cert_results`
+- `vault_pki_cert_ca_entries`
+- `vault_pki_cert_result` by default, configurable with
+  `vault_pki_cert_result_fact`

--- a/roles/vault_pki_cert/defaults/main.yml
+++ b/roles/vault_pki_cert/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+vault_pki_cert_addr: "{{ hc_vault_addr | default(vault_addr | default('', true), true) }}"
+vault_pki_cert_auth_method: "{{ hc_vault_auth_method | default('token', true) }}"
+vault_pki_cert_token: "{{ hc_vault_token | default('', true) }}"
+vault_pki_cert_role_id: "{{ hc_vault_role_id | default('', true) }}"
+vault_pki_cert_secret_id: "{{ hc_vault_secret_id | default('', true) }}"
+vault_pki_cert_validate_certs: "{{ hc_vault_validate_certs | default(true, true) }}"
+vault_pki_cert_mount_point: ""
+vault_pki_cert_service_names: []
+vault_pki_cert_services: {}
+vault_pki_cert_ttl: ""
+vault_pki_cert_format: pem
+vault_pki_cert_private_key_format: pkcs8
+vault_pki_cert_require_shared_ca: true
+vault_pki_cert_read_issuer: true
+vault_pki_cert_require_trust_anchor: true
+vault_pki_cert_result_fact: vault_pki_cert_result

--- a/roles/vault_pki_cert/meta/main.yml
+++ b/roles/vault_pki_cert/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Lightning IT
+  description: Issue generic service certificates from HashiCorp Vault PKI.
+  license: MIT
+  min_ansible_version: "2.15"
+dependencies: []

--- a/roles/vault_pki_cert/tasks/assert.yml
+++ b/roles/vault_pki_cert/tasks/assert.yml
@@ -1,0 +1,48 @@
+---
+- name: Validate Vault PKI certificate variables
+  ansible.builtin.assert:
+    that:
+      - vault_pki_cert_addr | default('', true) | trim | length > 0
+      - vault_pki_cert_auth_method in ['token', 'approle']
+      - vault_pki_cert_mount_point | default('', true) | trim | length > 0
+      - vault_pki_cert_service_names is sequence
+      - vault_pki_cert_service_names is not string
+      - vault_pki_cert_service_names | length > 0
+      - vault_pki_cert_services is mapping
+      - vault_pki_cert_validate_certs is boolean
+      - vault_pki_cert_require_shared_ca is boolean
+      - vault_pki_cert_read_issuer is boolean
+      - vault_pki_cert_require_trust_anchor is boolean
+    fail_msg: "Vault PKI certificate variables are missing or invalid."
+  tags: always
+
+- name: Validate Vault PKI token auth inputs
+  ansible.builtin.assert:
+    that:
+      - vault_pki_cert_token | default('', true) | trim | length > 0
+    fail_msg: "Vault PKI token auth requires vault_pki_cert_token."
+  when: vault_pki_cert_auth_method == 'token'
+  tags: always
+
+- name: Validate Vault PKI AppRole auth inputs
+  ansible.builtin.assert:
+    that:
+      - vault_pki_cert_role_id | default('', true) | trim | length > 0
+      - vault_pki_cert_secret_id | default('', true) | trim | length > 0
+    fail_msg: "Vault PKI AppRole auth requires role_id and secret_id."
+  when: vault_pki_cert_auth_method == 'approle'
+  tags: always
+
+- name: Validate Vault PKI service requests
+  ansible.builtin.assert:
+    that:
+      - vault_pki_cert_services[item] is mapping
+      - vault_pki_cert_services[item].role_name | default('', true) | trim | length > 0
+      - vault_pki_cert_services[item].common_name | default('', true) | trim | length > 0
+      - vault_pki_cert_services[item].alt_names | default([]) is sequence
+      - vault_pki_cert_services[item].alt_names | default([]) is not string
+      - vault_pki_cert_services[item].ip_sans | default([]) is sequence
+      - vault_pki_cert_services[item].ip_sans | default([]) is not string
+    fail_msg: "Each Vault PKI service request needs role_name, common_name, alt_names, and ip_sans."
+  loop: "{{ vault_pki_cert_service_names }}"
+  tags: always

--- a/roles/vault_pki_cert/tasks/main.yml
+++ b/roles/vault_pki_cert/tasks/main.yml
@@ -222,7 +222,7 @@
 
 - name: Record Vault PKI certificate result
   ansible.builtin.set_fact:
-    "{{ vault_pki_cert_result_fact }}":
+    vault_pki_cert_result:
       results: "{{ vault_pki_cert_results.results | default([]) }}"
       ca_entries: "{{ vault_pki_cert_ca_entries | default([]) }}"
       ca_bundle: "{{ vault_pki_cert_ca_entries | default([]) | join('\n') }}"

--- a/roles/vault_pki_cert/tasks/main.yml
+++ b/roles/vault_pki_cert/tasks/main.yml
@@ -1,0 +1,230 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Generate Vault PKI leaf certificates
+  community.hashi_vault.vault_pki_generate_certificate:
+    url: "{{ vault_pki_cert_addr }}"
+    auth_method: "{{ vault_pki_cert_auth_method }}"
+    token: >-
+      {{
+        vault_pki_cert_token
+        if (vault_pki_cert_token | default('', true) | trim | length > 0)
+        else omit
+      }}
+    role_id: >-
+      {{
+        vault_pki_cert_role_id
+        if (vault_pki_cert_role_id | default('', true) | trim | length > 0)
+        else omit
+      }}
+    secret_id: >-
+      {{
+        vault_pki_cert_secret_id
+        if (vault_pki_cert_secret_id | default('', true) | trim | length > 0)
+        else omit
+      }}
+    validate_certs: "{{ vault_pki_cert_validate_certs | bool }}"
+    engine_mount_point: "{{ vault_pki_cert_mount_point }}"
+    role_name: "{{ vault_pki_cert_services[item].role_name }}"
+    common_name: "{{ vault_pki_cert_services[item].common_name }}"
+    alt_names: "{{ vault_pki_cert_services[item].alt_names | default([]) }}"
+    ip_sans: "{{ vault_pki_cert_services[item].ip_sans | default([]) }}"
+    ttl: "{{ vault_pki_cert_ttl if (vault_pki_cert_ttl | default('', true) | trim | length > 0) else omit }}"
+    format: "{{ vault_pki_cert_format }}"
+    private_key_format: "{{ vault_pki_cert_private_key_format }}"
+  register: vault_pki_cert_results
+  loop: "{{ vault_pki_cert_service_names }}"
+  delegate_to: localhost
+  become: false
+  no_log: true
+
+- name: Build normalized Vault PKI CA bundle candidates
+  ansible.builtin.set_fact:
+    _vault_pki_cert_ca_bundles: >-
+      {{
+        (_vault_pki_cert_ca_bundles | default([]))
+        + [
+          (
+            (
+              (item.data.data.ca_chain | default([]))
+              + [(item.data.data.issuing_ca | default(''))]
+            )
+            | map('string')
+            | map('replace', '\r', '')
+            | map('replace', '\\n', "\n")
+            | map('trim')
+            | reject('equalto', '')
+            | unique
+            | join("\n")
+            | replace('\\n', "\n")
+            | regex_replace("\n+$", '')
+          )
+        ]
+      }}
+  loop: "{{ vault_pki_cert_results.results | default([]) }}"
+  changed_when: false
+  no_log: true
+
+- name: Ensure Vault PKI issued one shared CA bundle
+  ansible.builtin.assert:
+    that:
+      - (_vault_pki_cert_ca_bundles | default([]) | length) > 0
+      - (_vault_pki_cert_ca_bundles | default([]) | unique | length) == 1
+    fail_msg: "Vault PKI issued multiple CA bundles for the requested certificates."
+    quiet: true
+  when: vault_pki_cert_require_shared_ca | bool
+  no_log: true
+
+- name: Record shared Vault PKI CA entries
+  ansible.builtin.set_fact:
+    vault_pki_cert_ca_bundle: "{{ (_vault_pki_cert_ca_bundles | default([]) | unique | first) }}"
+    vault_pki_cert_ca_entries: >-
+      {{
+        (
+          (
+            vault_pki_cert_results.results | first
+          ).data.data.ca_chain | default([])
+        )
+        + [
+          (
+            (
+              vault_pki_cert_results.results | first
+            ).data.data.issuing_ca | default('')
+          )
+        ]
+      }}
+  changed_when: false
+  no_log: true
+
+- name: Inspect first Vault PKI CA certificate
+  community.crypto.x509_certificate_info:
+    content: "{{ vault_pki_cert_ca_entries | first }}"
+  register: vault_pki_cert_ca_first_info
+  delegate_to: localhost
+  become: false
+  when:
+    - vault_pki_cert_read_issuer | bool
+    - (vault_pki_cert_ca_entries | default([]) | length) > 0
+  no_log: true
+
+- name: Derive Vault PKI issuer certificate PEM URL
+  ansible.builtin.set_fact:
+    vault_pki_cert_ca_issuer_pem_url: >-
+      {{
+        vault_pki_cert_ca_first_info.issuer_uri
+        | default('', true)
+        | string
+        | trim
+        | regex_replace('/$', '')
+        | regex_replace('/ca$', '/ca/pem')
+      }}
+  changed_when: false
+  when:
+    - vault_pki_cert_read_issuer | bool
+    - vault_pki_cert_ca_first_info is defined
+  no_log: true
+
+- name: Read Vault PKI issuer certificate PEM from issuer URI
+  ansible.builtin.uri:
+    url: "{{ vault_pki_cert_ca_issuer_pem_url }}"
+    method: GET
+    return_content: true
+    validate_certs: "{{ vault_pki_cert_validate_certs | bool }}"
+    status_code: 200
+  register: vault_pki_cert_ca_issuer_pem
+  delegate_to: localhost
+  become: false
+  failed_when: false
+  when:
+    - vault_pki_cert_read_issuer | bool
+    - vault_pki_cert_ca_first_info is defined
+    - >-
+      (vault_pki_cert_ca_first_info.subject_ordered | default([]))
+      !=
+      (vault_pki_cert_ca_first_info.issuer_ordered | default([]))
+    - vault_pki_cert_ca_issuer_pem_url | default('', true) | trim | length > 0
+  no_log: true
+
+- name: Ensure Vault PKI issuer certificate is readable when CA is not self-signed
+  ansible.builtin.assert:
+    that:
+      - vault_pki_cert_ca_issuer_pem is defined
+      - not (vault_pki_cert_ca_issuer_pem.failed | default(false) | bool)
+      - vault_pki_cert_ca_issuer_pem.status | default(0) | int == 200
+      - vault_pki_cert_ca_issuer_pem.content | default('', true) | trim | length > 0
+    fail_msg: "Vault PKI returned a non-self-signed issuing CA, but the issuer certificate could not be read."
+    quiet: true
+  when:
+    - vault_pki_cert_read_issuer | bool
+    - vault_pki_cert_ca_first_info is defined
+    - >-
+      (vault_pki_cert_ca_first_info.subject_ordered | default([]))
+      !=
+      (vault_pki_cert_ca_first_info.issuer_ordered | default([]))
+  no_log: true
+
+- name: Append Vault PKI issuer certificate to shared CA entries
+  ansible.builtin.set_fact:
+    vault_pki_cert_ca_entries: >-
+      {{
+        (
+          (vault_pki_cert_ca_entries | default([]))
+          + [
+              (
+                vault_pki_cert_ca_issuer_pem.content
+                if (
+                  vault_pki_cert_ca_issuer_pem is defined
+                  and not (vault_pki_cert_ca_issuer_pem.failed | default(false) | bool)
+                  and (vault_pki_cert_ca_issuer_pem.status | default(0) | int) == 200
+                )
+                else ''
+              )
+            ]
+        )
+        | map('string')
+        | map('replace', '\r', '')
+        | map('replace', '\\n', "\n")
+        | map('trim')
+        | reject('equalto', '')
+        | unique
+        | list
+      }}
+  changed_when: false
+  when: vault_pki_cert_read_issuer | bool
+  no_log: true
+
+- name: Inspect final Vault PKI trust anchor certificate
+  community.crypto.x509_certificate_info:
+    content: "{{ vault_pki_cert_ca_entries | last }}"
+  register: vault_pki_cert_ca_last_info
+  delegate_to: localhost
+  become: false
+  when:
+    - vault_pki_cert_require_trust_anchor | bool
+    - (vault_pki_cert_ca_entries | default([]) | length) > 0
+  no_log: true
+
+- name: Ensure Vault PKI shared CA bundle ends at trust anchor
+  ansible.builtin.assert:
+    that:
+      - >-
+        (vault_pki_cert_ca_last_info.subject_ordered | default([]))
+        ==
+        (vault_pki_cert_ca_last_info.issuer_ordered | default([]))
+    fail_msg: "Vault PKI CA bundle does not end in a self-signed trust anchor."
+    quiet: true
+  when:
+    - vault_pki_cert_require_trust_anchor | bool
+    - vault_pki_cert_ca_last_info is defined
+  no_log: true
+
+- name: Record Vault PKI certificate result
+  ansible.builtin.set_fact:
+    "{{ vault_pki_cert_result_fact }}":
+      results: "{{ vault_pki_cert_results.results | default([]) }}"
+      ca_entries: "{{ vault_pki_cert_ca_entries | default([]) }}"
+      ca_bundle: "{{ vault_pki_cert_ca_entries | default([]) | join('\n') }}"
+  changed_when: false
+  no_log: true


### PR DESCRIPTION
Merges the podman_systemd/TLS/secret helper roles needed by supplementary and fixes ansible-lint failures on the branch.\n\nLocal verification:\n- bash scripts/devtools-ansible-lint.sh