### PR TITLE
docs: apply enterprise README standard

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,12 @@
+---
+config:
+  MD004: false
+  MD012: false
+  MD013: false
+  MD022: false
+  MD025: false
+  MD029: false
+  MD032: false
+  MD033: false
+  MD034: false
+  MD060: false

--- a/README.md
+++ b/README.md
@@ -10,43 +10,6 @@
 
 <!-- END LIT_QUALITY_BADGES -->
 
-<!-- BEGIN LIT_COMPATIBILITY_MATRIX -->
-
-## Compatibility Matrix
-
-| Collection Version | Role/Scenario | Platform | Product | Test Type | Validation |
-|---|---|---|---|---|---|
-| Current release | collection-sanity | ubuntu-latest | ansible-core, molecule | Collection sanity | See GitHub Release evidence |
-| Current release | molecule-light | ubuntu-latest | ansible-core, molecule | Molecule light | See GitHub Release evidence |
-| Current release | galaxy-build | ubuntu-latest | ansible-core, molecule | Galaxy build/publish | See GitHub Release evidence |
-
-Validation proof for each released version is stored in the corresponding GitHub Release evidence.
-
-<!-- END LIT_COMPATIBILITY_MATRIX -->
-
-<!-- BEGIN LIT_RELEASE_QUALITY_MODEL -->
-
-## Release and Quality Model
-
-This repository follows the Lightning IT shared release and quality model.
-The README shows the current supported and tested matrix.
-Exact per-version proof is stored with every GitHub Release as `release-evidence.md` and `release-evidence.json`.
-
-See:
-
-- [RELEASE.md](./RELEASE.md)
-- [TESTING.md](./TESTING.md)
-- [GitHub Releases](../../releases)
-
-Repository classification: **Ansible Collection**.
-Required test profiles: `pre-commit, lint, light, molecule-light, release-validation`.
-Publishing targets: `github-release, ansible-galaxy`.
-
-Release evidence records the exact GitHub Actions run, validated matrix rows, built artifacts, publish result, and security status for each release.
-
-<!-- END LIT_RELEASE_QUALITY_MODEL -->
-
-
 Foundational Ansible collection for ModuLix.
 It provides generic building blocks and orchestration helpers for consistent, repeatable automation.
 
@@ -289,3 +252,68 @@ Use this smoke test whenever you want to verify that the collection is:
 - buildable,
 - installable,
 - and usable via FQCN before pushing or tagging a release.
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for supported versions and vulnerability reporting.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution and review expectations.
+
+## License
+
+See [LICENSE](./LICENSE).
+
+<!-- BEGIN LIT_RELEASE_QUALITY_MODEL -->
+
+## Release and Quality Model
+
+This repository follows the Lightning IT shared release and quality model.
+The README shows the current supported and tested matrix.
+Exact per-version validation proof is stored with each GitHub Release as `release-evidence.md` and `release-evidence.json`.
+Releases are created from the protected `main` branch after a reviewed `develop -> main` release promotion.
+Collection releases validate collection sanity, Molecule scenarios, build integrity, and Ansible Galaxy publishing where enabled.
+
+See:
+
+- [RELEASE.md](./RELEASE.md)
+- [TESTING.md](./TESTING.md)
+- [GitHub Releases](../../releases)
+
+Repository classification: **Ansible Collection**.
+Required test profiles: `pre-commit, lint, light, molecule-light, release-validation`.
+Publishing targets: `github-release, ansible-galaxy`.
+
+<!-- END LIT_RELEASE_QUALITY_MODEL -->
+
+<!-- BEGIN LIT_COMPATIBILITY_MATRIX -->
+
+## Compatibility Matrix
+
+| Collection Version | Platform | Product | Validation |
+|---|---|---|---|
+| Latest release | ubuntu-latest | ansible-core, molecule | See release evidence |
+
+| Scenario | Test Type | Validation |
+|---|---|---|
+| collection-sanity | Collection sanity | See release evidence |
+| molecule-light | Molecule light | See release evidence |
+| galaxy-build | Galaxy build/publish | See release evidence |
+
+Validation proof for each released version is stored in the corresponding GitHub Release evidence.
+
+<!-- END LIT_COMPATIBILITY_MATRIX -->
+
+## Release Evidence
+
+Every released version includes immutable release evidence attached to the corresponding GitHub Release.
+The evidence records:
+
+- tested matrix combinations
+- GitHub Actions run links
+- artifact references
+- publish status
+- security scan status
+
+See [GitHub Releases](../../releases), [RELEASE.md](./RELEASE.md), and [TESTING.md](./TESTING.md) for the release process and validation model.

--- a/changelogs/fragments/enterprise-readme-standard.yml
+++ b/changelogs/fragments/enterprise-readme-standard.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docs - Apply the shared enterprise README structure.


### PR DESCRIPTION
## Summary
- apply the shared enterprise README order with project content first and quality/audit sections near the bottom
- add managed `LIT_QUALITY_BADGES`, `LIT_RELEASE_QUALITY_MODEL`, and `LIT_COMPATIBILITY_MATRIX` blocks
- add the shared markdownlint-cli2 config for local README validation

## Validation
- `python3 scripts/audit-release-model.py` from shared-assets
- `npx markdownlint-cli2 README.md RELEASE.md TESTING.md OPENSSF.md` across rollout repositories
- acceptance scan for no `(none)`, `undefined`, `null`, placeholder badge text, collapsed README lines, or generated symlinks
