### PR TITLE
chore: consolidate shared-assets-lit governance

### DIFF
--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -1,8 +1,9 @@
 ---
 schema_version: 1
-managed_by: lightning-it/shared-assets
+managed_by: lightning-it/shared-assets-lit
 repository: ansible-collection-foundational
 visibility: public
+license_spdx: MIT
 repository_type: ansible_collection
 release_type: ansible_galaxy
 artifact_type: ansible_collection_tarball
@@ -12,9 +13,9 @@ test_profiles:
   - light
   - molecule-light
   - release-validation
-os_matrix: &id001
+os_matrix:
   - ubuntu-latest
-product_matrix: &id002
+product_matrix:
   - ansible-core
   - molecule
 publishing_targets:
@@ -37,18 +38,3 @@ workflows:
   release: collection-publish.yml
   promote: promote-develop-to-main.yml
   backmerge: release-back-sync.yml
-collection_namespace: lit
-collection_name: foundational
-collection_version_source: galaxy.yml
-supported_platforms: *id001
-supported_products: *id002
-molecule_scenarios: &id003
-  - molecule-light
-light_test_scenarios: *id003
-heavy_incus_scenarios: []
-release_validation_scenarios:
-  - collection-sanity
-  - galaxy-build
-  - molecule-light
-required_secrets:
-  - GALAXY_API_TOKEN

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -1,6 +1,6 @@
 # OpenSSF Readiness
 
-This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets`.
+This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets-lit`.
 
 ## Repository
 
@@ -18,7 +18,7 @@ The Scorecard badge is included in `README.md` only for public repositories wher
 
 ## Best Practices Badge
 
-Not enrolled by shared-assets automation. Enroll manually at OpenSSF Best Practices, complete the project questionnaire, then add a badge only after the project is passing.
+Not enrolled by shared-assets-lit automation. Enroll manually at OpenSSF Best Practices, complete the project questionnaire, then add a badge only after the project is passing.
 
 Do not add a passing OpenSSF Best Practices badge until the repository is actually enrolled and passing.
 
@@ -29,9 +29,9 @@ Do not add a passing OpenSSF Best Practices badge until the repository is actual
 ## Branch Protection And Release Integrity
 
 - `main` is the protected release branch.
-- `develop` is the integration branch for normal work, Renovate, and shared-assets PRs.
+- `develop` is the integration branch for normal work, Renovate, and shared-assets-lit PRs.
 - `develop` to `main` promotion PRs require manual review.
-- Renovate and shared-assets PRs may auto-merge only into `develop` after required checks pass.
+- Renovate and shared-assets-lit PRs may auto-merge only into `develop` after required checks pass.
 - Releases and publishing happen only from trusted `main` workflows after validation.
 - Release evidence is generated for repositories with release artifacts.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
 # lit.foundational
 
+<!-- BEGIN LIT_SHARED_RELEASE_MODEL -->
+
+## Release and Quality Model
+
+This repository follows the Lightning IT shared release and quality model.
+
+See [RELEASE.md](./RELEASE.md) for:
+
+- branch and release flow
+- required quality checks
+- test matrix
+- release evidence
+- artifact publishing
+- supported repository-specific release behavior
+
+Repository classification: **Ansible Collection**.
+Required test profiles: `pre-commit, lint, light, molecule-light, release-validation`.
+Publishing targets: `github-release, ansible-galaxy`.
+
+## Supported and Tested Platforms
+
+| Platform / Product | Status | Validation |
+|---|---:|---|
+| ubuntu-latest | Supported | Molecule |
+| ansible-core | Tested where applicable | Molecule |
+| molecule | Tested where applicable | Molecule |
+
+<!-- END LIT_SHARED_RELEASE_MODEL -->
+
 <!-- BEGIN LIT_QUALITY_BADGES -->
 
 [![CI](https://github.com/lightning-it/ansible-collection-foundational/actions/workflows/collection-ci.yml/badge.svg?branch=develop)](https://github.com/lightning-it/ansible-collection-foundational/actions/workflows/collection-ci.yml)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ This repository follows the Lightning IT shared release and quality model.
 
 ## Branch Flow
 
-- `develop` is the integration branch for normal work, Renovate updates, and shared-assets synchronization.
+- `develop` is the integration branch for normal work, Renovate updates, and shared-assets-lit synchronization.
 - `main` is the protected release branch.
 - Releases happen only after `main` is updated.
 - A `develop` to `main` promotion PR is created automatically when releasable changes exist.

--- a/TESTING.md
+++ b/TESTING.md
@@ -24,7 +24,7 @@ Products and runtimes:
 ## When Tests Run
 
 - Normal pull requests run pre-commit, linting, syntax checks, and light tests relevant to changed files.
-- Renovate and shared-assets synchronization pull requests target `develop` and may auto-merge only after required checks pass.
+- Renovate and shared-assets-lit synchronization pull requests target `develop` and may auto-merge only after required checks pass.
 - `develop` to `main` promotion pull requests run the strongest validation profile for this repository.
 - Trusted `main` release workflows build and publish artifacts only after validation succeeds.
 

--- a/changelogs/fragments/shared-assets-lit-governance.yml
+++ b/changelogs/fragments/shared-assets-lit-governance.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docs - Consolidate generated governance metadata and license policy on shared-assets-lit.


### PR DESCRIPTION
Consolidates repository governance on `lightning-it/shared-assets-lit`.

This PR updates:
- source-of-truth metadata from `shared-assets` to `shared-assets-lit`
- generated release/testing/OpenSSF docs
- license policy metadata and MIT license drift corrections where applicable
- repository-quality checks for license/source drift
