### PR TITLE
chore: sync OpenSSF Best Practices readiness

### DIFF
--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -25,6 +25,11 @@ galaxy_publish: true
 quay_publish: false
 release_evidence: true
 heavy_incus_required: false
+openssf_best_practices:
+  required: true
+  project_id: null
+  target_level: passing
+  exception: null
 readme_badges:
   - ci
   - pre-commit

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -18,9 +18,9 @@ The Scorecard badge is included in `README.md` only for public repositories wher
 
 ## Best Practices Badge
 
-Not enrolled by shared-assets-lit automation. Enroll manually at OpenSSF Best Practices, complete the project questionnaire, then add a badge only after the project is passing.
+Required but not enrolled. Enroll manually at OpenSSF Best Practices, complete the questionnaire until the project reaches the configured target level, then record the numeric project ID in `openssf_best_practices.project_id` in `release-model/repositories.yml`.
 
-Do not add a passing OpenSSF Best Practices badge until the repository is actually enrolled and passing.
+Do not add a passing OpenSSF Best Practices badge until the repository is actually enrolled and passing. Badges must be generated from `release-model/repositories.yml`; hand-written badges are rejected by the release-model audit.
 
 ## Security Policy
 


### PR DESCRIPTION
Synchronize generated OpenSSF Best Practices readiness metadata and documentation.