### PR TITLE
feat: add guarded LUKS2 header escrow role

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ The current collection compatibility baseline is `ansible-core` 2.18.0 or newer.
   - keeps fallback explicit and disabled by default,
   - supports Vault KV v2 write-back and controlled bootstrap migration.
 
+- `lit.foundational.luks_header_escrow`
+  Persists one installed LUKS2 header as immutable controller-side Ansible
+  Vault ciphertext:
+  - validates one `crypttab` source, LUKS2 metadata, UUID, size, checksum, and
+    controller path containment,
+  - keeps raw header bytes off controller storage and always removes the
+    protected managed-host temporary copy.
+
 - `lit.foundational.terragrunt`
   Terragrunt wrapper that:
   - prepares a per-cluster working directory on the control host,

--- a/changelogs/fragments/luks-header-escrow-role.yml
+++ b/changelogs/fragments/luks-header-escrow-role.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - >-
+    luks_header_escrow - Add a guarded, distribution-neutral role that captures
+    one installed LUKS2 header and persists exact immutable controller-side
+    Ansible Vault ciphertext with explicit loaded-identity selection, canonical
+    block-device and protected remote-temporary-path validation, cryptographic
+    payload-to-metadata binding, and no controller plaintext.

--- a/molecule/hetzner-installimage-basic/files/functions.sh
+++ b/molecule/hetzner-installimage-basic/files/functions.sh
@@ -2,4 +2,5 @@
 # Synthetic feature markers used only by Molecule.
 CRYPTPASSWORD=""
 PART_CRYPT=""
+export CRYPTPASSWORD PART_CRYPT
 encrypt_partitions() { :; }

--- a/molecule/luks-header-escrow-basic/cleanup.yml
+++ b/molecule/luks-header-escrow-basic/cleanup.yml
@@ -1,0 +1,17 @@
+---
+- name: Clean up regular-file LUKS2 fixtures
+  hosts: luks-header-escrow-target
+  gather_facts: false
+  become: false
+  vars:
+    luks_header_escrow_molecule_root: >-
+      {{ lookup('ansible.builtin.env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}
+  tasks:
+    - name: Remove scenario-owned fixture and escrow roots
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /dev/shm/lit-foundational-luks-header-escrow-basic
+        - "{{ luks_header_escrow_molecule_root }}/fixtures"
+        - "{{ luks_header_escrow_molecule_root }}/controller-escrow"

--- a/molecule/luks-header-escrow-basic/converge.yml
+++ b/molecule/luks-header-escrow-basic/converge.yml
@@ -1,0 +1,80 @@
+---
+- name: Converge LUKS-header escrow
+  hosts: luks-header-escrow-target
+  gather_facts: false
+  become: false
+  vars:
+    luks_header_escrow_molecule_root: >-
+      {{ lookup('ansible.builtin.env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}
+    luks_header_escrow_molecule_fixture_root: >-
+      {{ luks_header_escrow_molecule_root }}/fixtures
+    luks_header_escrow_molecule_controller_root: >-
+      {{ luks_header_escrow_molecule_root }}/controller-escrow
+    luks_header_escrow_molecule_runtime_root: >-
+      /dev/shm/lit-foundational-luks-header-escrow-basic/runtime
+    luks_header_escrow_molecule_path: >-
+      {{ luks_header_escrow_molecule_controller_root }}/header.vault.yml
+
+  pre_tasks:
+    - name: Create protected escrow and runtime roots
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0700"
+      loop:
+        - "{{ luks_header_escrow_molecule_controller_root }}"
+        - "{{ luks_header_escrow_molecule_runtime_root }}"
+
+  tasks:
+    - name: Exercise the disabled no-op contract
+      ansible.builtin.include_role:
+        name: lit.foundational.luks_header_escrow
+      vars:
+        luks_header_escrow_enabled: false
+
+    - name: Exercise the controller-only preflight entrypoint
+      ansible.builtin.include_role:
+        name: lit.foundational.luks_header_escrow
+        tasks_from: preflight
+      vars:
+        luks_header_escrow_enabled: true
+        luks_header_escrow_path: "{{ luks_header_escrow_molecule_path }}"
+        luks_header_escrow_controller_root_path: >-
+          {{ luks_header_escrow_molecule_controller_root }}
+        luks_header_escrow_crypttab_path: >-
+          {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+        luks_header_escrow_findfs_path: >-
+          {{ luks_header_escrow_molecule_fixture_root }}/findfs
+        luks_header_escrow_remote_temporary_root: >-
+          {{ luks_header_escrow_molecule_runtime_root }}
+
+    - name: Persist the real LUKS2 fixture header as immutable ciphertext
+      ansible.builtin.include_role:
+        name: lit.foundational.luks_header_escrow
+      vars:
+        luks_header_escrow_enabled: true
+        luks_header_escrow_path: "{{ luks_header_escrow_molecule_path }}"
+        luks_header_escrow_controller_root_path: >-
+          {{ luks_header_escrow_molecule_controller_root }}
+        luks_header_escrow_crypttab_path: >-
+          {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+        luks_header_escrow_findfs_path: >-
+          {{ luks_header_escrow_molecule_fixture_root }}/findfs
+        luks_header_escrow_remote_temporary_root: >-
+          {{ luks_header_escrow_molecule_runtime_root }}
+        luks_header_escrow_allow_regular_file_device: true
+
+    - name: Require a secret-free successful result
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_result.created is boolean
+          - luks_header_escrow_result.exists is boolean
+          - luks_header_escrow_result.exists
+          - luks_header_escrow_result.path == luks_header_escrow_molecule_path
+          - >-
+            luks_header_escrow_result.ciphertext_sha256
+            is match('^[0-9a-f]{64}$')
+          - >-
+            luks_header_escrow_result.luks_uuid
+            == '11111111-2222-4333-8444-555555555555'
+        quiet: true

--- a/molecule/luks-header-escrow-basic/molecule.yml
+++ b/molecule/luks-header-escrow-basic/molecule.yml
@@ -1,0 +1,49 @@
+---
+dependency:
+  name: shell
+  command: |-
+    set -euo pipefail
+    install -d -m 0700 "${MOLECULE_EPHEMERAL_DIRECTORY}"
+    if [ ! -s "${MOLECULE_EPHEMERAL_DIRECTORY}/ansible-vault-password" ]; then
+      umask 077
+      head -c 48 /dev/urandom | base64 > "${MOLECULE_EPHEMERAL_DIRECTORY}/ansible-vault-password"
+    fi
+    chmod 0600 "${MOLECULE_EPHEMERAL_DIRECTORY}/ansible-vault-password"
+
+driver:
+  name: default
+
+platforms:
+  - name: luks-header-escrow-target
+    managed: false
+
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_VAULT_PASSWORD_FILE: "${MOLECULE_EPHEMERAL_DIRECTORY}/ansible-vault-password"
+  inventory:
+    host_vars:
+      luks-header-escrow-target:
+        ansible_connection: local
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+    verify: verify.yml
+    cleanup: cleanup.yml
+
+scenario:
+  name: luks-header-escrow-basic
+  test_sequence:
+    - destroy
+    - dependency
+    - cleanup
+    - syntax
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+
+verifier:
+  name: ansible

--- a/molecule/luks-header-escrow-basic/prepare.yml
+++ b/molecule/luks-header-escrow-basic/prepare.yml
@@ -1,0 +1,97 @@
+---
+- name: Prepare a regular-file LUKS2 fixture
+  hosts: luks-header-escrow-target
+  gather_facts: false
+  become: false
+  vars:
+    luks_header_escrow_molecule_uuid: 11111111-2222-4333-8444-555555555555
+    luks_header_escrow_molecule_device_root: >-
+      /dev/shm/lit-foundational-luks-header-escrow-basic
+    luks_header_escrow_molecule_device: >-
+      {{ luks_header_escrow_molecule_device_root }}/device.img
+    luks_header_escrow_molecule_key_file: >-
+      {{ luks_header_escrow_molecule_device_root }}/luks-key
+    luks_header_escrow_molecule_fixture_root: >-
+      {{ lookup('ansible.builtin.env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/fixtures
+
+  tasks:
+    - name: Reset the regular-file LUKS2 fixture root
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}"
+        state: absent
+
+    - name: Create protected fixture directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0700"
+      loop:
+        - "{{ luks_header_escrow_molecule_device_root }}"
+        - "{{ luks_header_escrow_molecule_fixture_root }}"
+
+    - name: Allocate a sparse regular-file LUKS2 device
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/truncate
+          - --size
+          - 32M
+          - "{{ luks_header_escrow_molecule_device }}"
+      changed_when: true
+
+    - name: Generate an ephemeral LUKS fixture key
+      ansible.builtin.shell: |
+        set -o pipefail
+        umask 077
+        head -c 48 /dev/urandom \
+          | base64 > "${_LUKS_HEADER_ESCROW_MOLECULE_KEY_FILE}"
+      args:
+        executable: /bin/bash
+      environment:
+        _LUKS_HEADER_ESCROW_MOLECULE_KEY_FILE: >-
+          {{ luks_header_escrow_molecule_key_file }}
+      changed_when: true
+      no_log: true
+
+    - name: Format the regular file as LUKS2 without opening it
+      ansible.builtin.command:
+        argv:
+          - /usr/sbin/cryptsetup
+          - luksFormat
+          - --type
+          - luks2
+          - --batch-mode
+          - --pbkdf
+          - pbkdf2
+          - --pbkdf-force-iterations
+          - "1000"
+          - --uuid
+          - "{{ luks_header_escrow_molecule_uuid }}"
+          - --key-file
+          - "{{ luks_header_escrow_molecule_key_file }}"
+          - "{{ luks_header_escrow_molecule_device }}"
+      changed_when: true
+      no_log: true
+
+    - name: Remove the ephemeral LUKS fixture key
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_key_file }}"
+        state: absent
+      no_log: true
+
+    - name: Write the single-source crypttab fixture
+      ansible.builtin.copy:
+        dest: "{{ luks_header_escrow_molecule_fixture_root }}/crypttab"
+        content: >-
+          cryptroot UUID={{ luks_header_escrow_molecule_uuid }} none luks
+        mode: "0600"
+
+    - name: Write the constrained findfs fixture
+      ansible.builtin.copy:
+        dest: "{{ luks_header_escrow_molecule_fixture_root }}/findfs"
+        mode: "0700"
+        content: |
+          #!/bin/bash
+          set -euo pipefail
+          test "$#" -eq 1
+          test "$1" = "UUID={{ luks_header_escrow_molecule_uuid }}"
+          printf '%s\n' '{{ luks_header_escrow_molecule_device }}'

--- a/molecule/luks-header-escrow-basic/verify.yml
+++ b/molecule/luks-header-escrow-basic/verify.yml
@@ -1,0 +1,661 @@
+---
+- name: Verify LUKS-header escrow
+  hosts: luks-header-escrow-target
+  gather_facts: false
+  become: false
+  vars:
+    luks_header_escrow_molecule_uuid: 11111111-2222-4333-8444-555555555555
+    luks_header_escrow_molecule_root: >-
+      {{ lookup('ansible.builtin.env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}
+    luks_header_escrow_molecule_device_root: >-
+      /dev/shm/lit-foundational-luks-header-escrow-basic
+    luks_header_escrow_molecule_device: >-
+      {{ luks_header_escrow_molecule_device_root }}/device.img
+    luks_header_escrow_molecule_fixture_root: >-
+      {{ luks_header_escrow_molecule_root }}/fixtures
+    luks_header_escrow_molecule_controller_root: >-
+      {{ luks_header_escrow_molecule_root }}/controller-escrow
+    luks_header_escrow_molecule_runtime_root: >-
+      {{ luks_header_escrow_molecule_device_root }}/runtime
+    luks_header_escrow_molecule_path: >-
+      {{ luks_header_escrow_molecule_controller_root }}/header.vault.yml
+
+  tasks:
+    - name: Inspect the encrypted controller document
+      ansible.builtin.stat:
+        path: "{{ luks_header_escrow_molecule_path }}"
+        follow: false
+        get_checksum: true
+        checksum_algorithm: sha256
+      register: luks_header_escrow_molecule_ciphertext_stat
+      changed_when: false
+
+    - name: Read the encrypted controller document signature
+      ansible.builtin.slurp:
+        src: "{{ luks_header_escrow_molecule_path }}"
+      register: luks_header_escrow_molecule_ciphertext
+      changed_when: false
+
+    - name: Require protected ciphertext without plaintext markers
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_ciphertext_stat.stat.isreg | default(false)
+          - luks_header_escrow_molecule_ciphertext_stat.stat.mode == '0600'
+          - >-
+            (luks_header_escrow_molecule_ciphertext.content | b64decode)
+            is match('^\\$ANSIBLE_VAULT;')
+          - >-
+            'luks_header_b64'
+            not in (luks_header_escrow_molecule_ciphertext.content | b64decode)
+          - >-
+            inventory_hostname
+            not in (luks_header_escrow_molecule_ciphertext.content | b64decode)
+        quiet: true
+
+    - name: Decrypt the controller document only into protected Ansible memory
+      ansible.builtin.include_vars:
+        file: "{{ luks_header_escrow_molecule_path }}"
+        name: luks_header_escrow_molecule_document
+      no_log: true
+
+    - name: Create an independent expected header backup
+      ansible.builtin.command:
+        argv:
+          - /usr/sbin/cryptsetup
+          - luksHeaderBackup
+          - "{{ luks_header_escrow_molecule_device }}"
+          - --header-backup-file
+          - "{{ luks_header_escrow_molecule_device_root }}/expected-header.luks"
+      changed_when: true
+      no_log: true
+
+    - name: Inspect the independent expected header backup
+      ansible.builtin.stat:
+        path: "{{ luks_header_escrow_molecule_device_root }}/expected-header.luks"
+        get_checksum: true
+        checksum_algorithm: sha256
+      register: luks_header_escrow_molecule_expected_header_stat
+      changed_when: false
+      no_log: true
+
+    - name: Read the independent expected header backup
+      ansible.builtin.slurp:
+        src: "{{ luks_header_escrow_molecule_device_root }}/expected-header.luks"
+      register: luks_header_escrow_molecule_expected_header
+      changed_when: false
+      no_log: true
+
+    - name: Derive secret-free exact document checks
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_document_keys_match: >-
+          {{
+            luks_header_escrow_molecule_document.keys() | list | sort
+            == [
+              'luks_format',
+              'luks_header_b64',
+              'luks_header_raw_size_bytes',
+              'luks_header_sha256_raw',
+              'luks_uuid',
+              'schema_version',
+              'subject'
+            ]
+          }}
+        luks_header_escrow_molecule_schema_type_matches: >-
+          {{
+            luks_header_escrow_molecule_document.schema_version
+            | type_debug == 'int'
+          }}
+        luks_header_escrow_molecule_schema_value_matches: >-
+          {{ luks_header_escrow_molecule_document.schema_version == 1 }}
+        luks_header_escrow_molecule_subject_matches: >-
+          {{
+            luks_header_escrow_molecule_document.subject
+            == inventory_hostname
+          }}
+        luks_header_escrow_molecule_format_matches: >-
+          {{ luks_header_escrow_molecule_document.luks_format == 'luks2' }}
+        luks_header_escrow_molecule_uuid_matches: >-
+          {{
+            luks_header_escrow_molecule_document.luks_uuid
+            == luks_header_escrow_molecule_uuid
+          }}
+        luks_header_escrow_molecule_size_type_matches: >-
+          {{
+            luks_header_escrow_molecule_document.luks_header_raw_size_bytes
+            | type_debug == 'int'
+          }}
+        luks_header_escrow_molecule_header_checksum_matches: >-
+          {{
+            luks_header_escrow_molecule_document.luks_header_sha256_raw
+            == luks_header_escrow_molecule_expected_header_stat.stat.checksum
+          }}
+        luks_header_escrow_molecule_header_size_matches: >-
+          {{
+            luks_header_escrow_molecule_document.luks_header_raw_size_bytes
+            == luks_header_escrow_molecule_expected_header_stat.stat.size
+          }}
+        luks_header_escrow_molecule_header_payload_matches: >-
+          {{
+            luks_header_escrow_molecule_document.luks_header_b64
+            == luks_header_escrow_molecule_expected_header.content
+          }}
+      changed_when: false
+      no_log: true
+
+    - name: Require the exact LUKS2 escrow document
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_document_keys_match | bool
+          - luks_header_escrow_molecule_schema_type_matches | bool
+          - luks_header_escrow_molecule_schema_value_matches | bool
+          - luks_header_escrow_molecule_subject_matches | bool
+          - luks_header_escrow_molecule_format_matches | bool
+          - luks_header_escrow_molecule_uuid_matches | bool
+          - luks_header_escrow_molecule_size_type_matches | bool
+          - luks_header_escrow_molecule_header_checksum_matches | bool
+          - luks_header_escrow_molecule_header_size_matches | bool
+          - luks_header_escrow_molecule_header_payload_matches | bool
+        quiet: true
+
+    - name: Remove the independent expected header backup
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/expected-header.luks"
+        state: absent
+      no_log: true
+
+    - name: Find leaked remote header directories
+      ansible.builtin.find:
+        paths: "{{ luks_header_escrow_molecule_runtime_root }}"
+        patterns: lit-luks-header-escrow-*
+        file_type: directory
+      register: luks_header_escrow_molecule_leaked_directories
+      changed_when: false
+
+    - name: Require remote raw-header cleanup
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_leaked_directories.matched == 0
+        quiet: true
+
+    - name: Create an intentionally attacker-writable remote root
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/insecure-remote-root"
+        state: directory
+        mode: "0777"
+
+    - name: Initialize insecure remote root refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_insecure_remote_root_refused: false
+      changed_when: false
+
+    - name: Exercise attacker-writable remote root refusal
+      block:
+        - name: Attempt escrow with an attacker-writable remote root
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/insecure-remote.vault.yml
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_device_root }}/insecure-remote-root
+            luks_header_escrow_allow_regular_file_device: true
+
+      rescue:
+        - name: Require protected-root validation to reject remote permissions
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require a protected managed-host temporary root'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record insecure remote root refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_insecure_remote_root_refused: true
+          changed_when: false
+
+    - name: Inspect refused remote-root ciphertext path
+      ansible.builtin.stat:
+        path: >-
+          {{ luks_header_escrow_molecule_controller_root }}/insecure-remote.vault.yml
+      register: luks_header_escrow_molecule_insecure_remote_ciphertext
+      changed_when: false
+
+    - name: Require safe attacker-writable remote root refusal
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_insecure_remote_root_refused
+          - >-
+            not (
+              luks_header_escrow_molecule_insecure_remote_ciphertext.stat.exists
+              | default(false)
+            )
+        quiet: true
+
+    - name: Remove the intentionally attacker-writable remote root
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/insecure-remote-root"
+        state: absent
+
+    - name: Create an attacker-writable remote-root parent
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/insecure-remote-parent"
+        state: directory
+        mode: "0777"
+
+    - name: Create a private leaf below the attacker-writable parent
+      ansible.builtin.file:
+        path: >-
+          {{ luks_header_escrow_molecule_device_root }}/insecure-remote-parent/private
+        state: directory
+        mode: "0700"
+
+    - name: Initialize insecure remote ancestry refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_insecure_remote_ancestry_refused: false
+      changed_when: false
+
+    - name: Exercise attacker-writable remote ancestry refusal
+      block:
+        - name: Attempt escrow below attacker-writable remote ancestry
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/insecure-ancestry.vault.yml
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_device_root }}/insecure-remote-parent/private
+            luks_header_escrow_allow_regular_file_device: true
+
+      rescue:
+        - name: Require ancestry validation to reject remote permissions
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require protected managed-host temporary-root ancestry'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record insecure remote ancestry refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_insecure_remote_ancestry_refused: true
+          changed_when: false
+
+    - name: Inspect refused remote-ancestry ciphertext path
+      ansible.builtin.stat:
+        path: >-
+          {{ luks_header_escrow_molecule_controller_root }}/insecure-ancestry.vault.yml
+      register: luks_header_escrow_molecule_insecure_ancestry_ciphertext
+      changed_when: false
+
+    - name: Require safe attacker-writable remote ancestry refusal
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_insecure_remote_ancestry_refused
+          - >-
+            not (
+              luks_header_escrow_molecule_insecure_ancestry_ciphertext.stat.exists
+              | default(false)
+            )
+        quiet: true
+
+    - name: Remove the attacker-writable remote-root parent
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/insecure-remote-parent"
+        state: absent
+
+    - name: Create an intentionally insecure controller escrow root
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_root }}/insecure-controller-root"
+        state: directory
+        mode: "0755"
+
+    - name: Initialize insecure controller root refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_insecure_root_refused: false
+      changed_when: false
+
+    - name: Exercise insecure controller root refusal
+      block:
+        - name: Attempt preflight with an insecure controller root
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+            tasks_from: preflight
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_root }}/insecure-controller-root
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_root }}/insecure-controller-root/header.vault.yml
+
+      rescue:
+        - name: Require private-root validation to reject insecure permissions
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require a private controller-owned escrow root'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record insecure controller root refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_insecure_root_refused: true
+          changed_when: false
+
+    - name: Remove the intentionally insecure controller root
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_root }}/insecure-controller-root"
+        state: absent
+
+    - name: Initialize controller path escape refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_path_escape_refused: false
+      changed_when: false
+
+    - name: Exercise controller path escape refusal
+      block:
+        - name: Attempt preflight with an escaping controller path
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+            tasks_from: preflight
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/../escaped.vault.yml
+
+      rescue:
+        - name: Require path containment validation to reject escape
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require the canonical escrow path below the controller root'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record controller path escape refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_path_escape_refused: true
+          changed_when: false
+
+    - name: Require controller root and path safety refusals
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_insecure_root_refused
+          - luks_header_escrow_molecule_path_escape_refused
+        quiet: true
+
+    - name: Write an ambiguous multi-source crypttab fixture
+      ansible.builtin.copy:
+        dest: "{{ luks_header_escrow_molecule_fixture_root }}/crypttab-multiple"
+        mode: "0600"
+        content: |
+          cryptroot UUID={{ luks_header_escrow_molecule_uuid }} none luks
+          cryptdata UUID=aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee none luks
+
+    - name: Initialize multiple crypttab source refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_multiple_sources_refused: false
+      changed_when: false
+
+    - name: Exercise multiple crypttab source refusal
+      block:
+        - name: Attempt escrow with multiple crypttab sources
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/multiple.vault.yml
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab-multiple
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_runtime_root }}
+            luks_header_escrow_allow_regular_file_device: true
+
+      rescue:
+        - name: Require exact-source validation to reject ambiguity
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require exactly one encrypted source declaration'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record multiple crypttab source refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_multiple_sources_refused: true
+          changed_when: false
+
+    - name: Require multiple crypttab source refusal
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_multiple_sources_refused
+        quiet: true
+
+    - name: Generate a second ephemeral LUKS fixture key
+      ansible.builtin.shell: |
+        set -o pipefail
+        umask 077
+        head -c 48 /dev/urandom \
+          | base64 > "${_LUKS_HEADER_ESCROW_MOLECULE_KEY_FILE}"
+      args:
+        executable: /bin/bash
+      environment:
+        _LUKS_HEADER_ESCROW_MOLECULE_KEY_FILE: >-
+          {{ luks_header_escrow_molecule_device_root }}/luks-key-two
+      changed_when: true
+      no_log: true
+
+    - name: Reformat the regular-file fixture with a different UUID
+      ansible.builtin.command:
+        argv:
+          - /usr/sbin/cryptsetup
+          - luksFormat
+          - --type
+          - luks2
+          - --batch-mode
+          - --pbkdf
+          - pbkdf2
+          - --pbkdf-force-iterations
+          - "1000"
+          - --uuid
+          - aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee
+          - --key-file
+          - "{{ luks_header_escrow_molecule_device_root }}/luks-key-two"
+          - "{{ luks_header_escrow_molecule_device }}"
+      changed_when: true
+      no_log: true
+
+    - name: Remove the second ephemeral LUKS fixture key
+      ansible.builtin.file:
+        path: "{{ luks_header_escrow_molecule_device_root }}/luks-key-two"
+        state: absent
+      no_log: true
+
+    - name: Initialize immutable-drift refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_drift_refused: false
+      changed_when: false
+
+    - name: Exercise immutable ciphertext drift refusal
+      block:
+        - name: Attempt escrow after the LUKS2 UUID changed
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: "{{ luks_header_escrow_molecule_path }}"
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_runtime_root }}
+            luks_header_escrow_allow_regular_file_device: true
+
+      rescue:
+        - name: Require the immutable document action to reject drift
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Persist the immutable encrypted controller escrow'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record immutable ciphertext drift refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_drift_refused: true
+          changed_when: false
+
+    - name: Reinspect ciphertext after refused drift
+      ansible.builtin.stat:
+        path: "{{ luks_header_escrow_molecule_path }}"
+        get_checksum: true
+        checksum_algorithm: sha256
+      register: luks_header_escrow_molecule_ciphertext_after_drift
+      changed_when: false
+
+    - name: Find leaked directories after refused drift
+      ansible.builtin.find:
+        paths: "{{ luks_header_escrow_molecule_runtime_root }}"
+        patterns: lit-luks-header-escrow-*
+        file_type: directory
+      register: luks_header_escrow_molecule_drift_leaks
+      changed_when: false
+
+    - name: Require immutable refusal, unchanged ciphertext, and cleanup
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_drift_refused
+          - >-
+            luks_header_escrow_molecule_ciphertext_after_drift.stat.checksum
+            == luks_header_escrow_molecule_ciphertext_stat.stat.checksum
+          - luks_header_escrow_molecule_drift_leaks.matched == 0
+        quiet: true
+
+    - name: Initialize unmatched Vault identity refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_vault_id_refused: false
+      changed_when: false
+
+    - name: Exercise unmatched loaded Vault identity refusal
+      block:
+        - name: Attempt escrow with an unloaded Vault identity
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/unmatched.vault.yml
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_vault_id: identity-not-loaded
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_runtime_root }}
+            luks_header_escrow_allow_regular_file_device: true
+
+      rescue:
+        - name: Require identity selection to fail at encrypted persistence
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Persist the immutable encrypted controller escrow'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record unmatched Vault identity refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_vault_id_refused: true
+          changed_when: false
+
+    - name: Inspect an unmatched-identity ciphertext path
+      ansible.builtin.stat:
+        path: >-
+          {{ luks_header_escrow_molecule_controller_root }}/unmatched.vault.yml
+      register: luks_header_escrow_molecule_unmatched_ciphertext
+      changed_when: false
+
+    - name: Find leaked directories after unmatched identity refusal
+      ansible.builtin.find:
+        paths: "{{ luks_header_escrow_molecule_runtime_root }}"
+        patterns: lit-luks-header-escrow-*
+        file_type: directory
+      register: luks_header_escrow_molecule_identity_leaks
+      changed_when: false
+
+    - name: Require safe unmatched identity refusal and cleanup
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_vault_id_refused
+          - not (luks_header_escrow_molecule_unmatched_ciphertext.stat.exists | default(false))
+          - luks_header_escrow_molecule_identity_leaks.matched == 0
+        quiet: true
+
+    - name: Initialize regular-file source refusal result
+      ansible.builtin.set_fact:
+        luks_header_escrow_molecule_regular_file_refused: false
+      changed_when: false
+
+    - name: Exercise regular-file source refusal without explicit opt-in
+      block:
+        - name: Attempt escrow from a regular file without test mode
+          ansible.builtin.include_role:
+            name: lit.foundational.luks_header_escrow
+          vars:
+            luks_header_escrow_enabled: true
+            luks_header_escrow_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}/regular.vault.yml
+            luks_header_escrow_controller_root_path: >-
+              {{ luks_header_escrow_molecule_controller_root }}
+            luks_header_escrow_crypttab_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/crypttab
+            luks_header_escrow_findfs_path: >-
+              {{ luks_header_escrow_molecule_fixture_root }}/findfs
+            luks_header_escrow_remote_temporary_root: >-
+              {{ luks_header_escrow_molecule_runtime_root }}
+
+      rescue:
+        - name: Require canonical device-type validation to reject the source
+          ansible.builtin.assert:
+            that:
+              - >-
+                'Require a block device unless regular-file mode is explicitly enabled'
+                in ansible_failed_task.name
+            quiet: true
+
+        - name: Record regular-file source refusal
+          ansible.builtin.set_fact:
+            luks_header_escrow_molecule_regular_file_refused: true
+          changed_when: false
+
+    - name: Require regular-file refusal without ciphertext creation
+      ansible.builtin.assert:
+        that:
+          - luks_header_escrow_molecule_regular_file_refused
+        quiet: true

--- a/plugins/action/ansible_vault_document.py
+++ b/plugins/action/ansible_vault_document.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import os
+import re
 
 from ansible.parsing.vault import VaultLib
 from ansible.plugins.action import ActionBase
@@ -41,8 +42,17 @@ options:
       - The task must set C(no_log=true); the action fails closed before inspecting this value otherwise.
     type: dict
     required: true
+  vault_id:
+    version_added: "1.29.0"
+    description:
+      - Loaded Ansible Vault identity label to use when creating an absent document.
+      - The label may contain only ASCII letters, digits, dots, underscores, and hyphens.
+      - The action never accepts or loads Vault password material.
+      - Existing documents are validated with the identities already loaded by Ansible.
+    type: str
 notes:
   - This action never contacts a managed host and never accepts a Vault password or password-file argument.
+  - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
   - Plaintext and ciphertext each have a fixed 128 MiB safety limit; the limit is not caller-configurable.
@@ -57,6 +67,7 @@ EXAMPLES = r"""
 - name: Persist an immutable encrypted bootstrap document
   lit.foundational.ansible_vault_document:
     path: /secure/inventory/bootstrap/service01.vault.yml
+    vault_id: production
     document:
       schema_version: 1
       subject: service01.example.test
@@ -84,8 +95,9 @@ ciphertext_sha256:
 """
 
 
-_EXPECTED_ARGS = frozenset(("path", "document"))
+_EXPECTED_ARGS = frozenset(("path", "document", "vault_id"))
 _MAX_DOCUMENT_BYTES = 128 * 1024 * 1024
+_VAULT_ID_PATTERN = re.compile(r"[A-Za-z0-9_.-]+\Z", re.ASCII)
 
 
 def _normalize_arguments(args):
@@ -110,9 +122,19 @@ def _normalize_arguments(args):
         _fail("document is required.")
     document = _normalize_document_mapping(args["document"])
 
+    vault_id = args.get("vault_id")
+    if vault_id is not None:
+        if not isinstance(vault_id, str) or not _VAULT_ID_PATTERN.fullmatch(vault_id):
+            _fail(
+                "vault_id may contain only ASCII letters, digits, dots, "
+                "underscores, and hyphens."
+            )
+        vault_id = str.__str__(vault_id)
+
     return {
         "path": normalized_path,
         "document": document,
+        "vault_id": vault_id,
     }
 
 
@@ -128,6 +150,22 @@ def _new_document_store(vault):
         max_ciphertext_bytes=_MAX_DOCUMENT_BYTES,
         max_plaintext_bytes=_MAX_DOCUMENT_BYTES,
     )
+
+
+def _select_vault_secret(vault, vault_id):
+    """Resolve one explicitly labelled identity without accepting secret input."""
+
+    if vault_id is None:
+        return None, None
+
+    matches = [
+        secret
+        for loaded_vault_id, secret in vault.secrets
+        if loaded_vault_id == vault_id
+    ]
+    if len(matches) != 1:
+        _fail("vault_id must identify exactly one loaded Ansible Vault identity.")
+    return matches[0], vault_id
 
 
 class ActionModule(ActionBase):
@@ -149,8 +187,12 @@ class ActionModule(ActionBase):
         if not isinstance(vault, VaultLib) or not getattr(vault, "secrets", None):
             _fail("An Ansible Vault identity must already be loaded for this action.")
 
+        vault_secret, vault_id = _select_vault_secret(vault, config["vault_id"])
+
         return _new_document_store(vault).ensure_exact(
             path=config["path"],
             document=config["document"],
             check_mode=bool(self._task.check_mode),
+            vault_secret=vault_secret,
+            vault_id=vault_id,
         )

--- a/plugins/action/ansible_vault_secret_document.py
+++ b/plugins/action/ansible_vault_secret_document.py
@@ -411,7 +411,14 @@ class _VaultSecretDocumentStore:
             digest = self._load_race_winner(path, **validation_args)
         return self._result(path, created=created, exists=True, digest=digest)
 
-    def ensure_exact(self, path, document, check_mode=False):
+    def ensure_exact(
+        self,
+        path,
+        document,
+        check_mode=False,
+        vault_secret=None,
+        vault_id=None,
+    ):
         """Create an exact immutable mapping or validate the existing mapping."""
 
         expected_document = _normalize_document_mapping(document)
@@ -432,11 +439,19 @@ class _VaultSecretDocumentStore:
         encrypted = None
         try:
             plaintext = self._serialize_document(expected_document)
-            encrypted = self._vault.encrypt(plaintext)
+            encrypted = self._vault.encrypt(
+                plaintext,
+                secret=vault_secret,
+                vault_id=vault_id,
+            )
             if not isinstance(encrypted, bytes):
                 encrypted = bytes(encrypted)
             if len(encrypted) > self._max_ciphertext_bytes:
                 _fail("The encrypted document is unexpectedly large.")
+            # Fail closed before the immutable create-if-absent publication if
+            # the Vault backend produced ciphertext that cannot be read back
+            # exactly with the controller's loaded identities.
+            self._validate_exact_ciphertext(encrypted, expected_document)
             created = self._exclusive_create(path, encrypted)
         except AnsibleActionFail:
             raise

--- a/plugins/modules/ansible_vault_document.py
+++ b/plugins/modules/ansible_vault_document.py
@@ -30,6 +30,14 @@ options:
       - The task must set C(no_log=true); the action fails closed before inspecting this value otherwise.
     type: dict
     required: true
+  vault_id:
+    version_added: "1.29.0"
+    description:
+      - Loaded Ansible Vault identity label to use when creating an absent document.
+      - The label may contain only ASCII letters, digits, dots, underscores, and hyphens.
+      - The action never accepts or loads Vault password material.
+      - Existing documents are validated with the identities already loaded by Ansible.
+    type: str
 attributes:
   action:
     description: The action executes entirely on the controller.
@@ -46,6 +54,7 @@ attributes:
 notes:
   - This documentation stub has no remote implementation; all behavior is provided by the matching action plugin.
   - The action never accepts a Vault password or password-file argument.
+  - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
   - Plaintext and ciphertext each have a fixed 128 MiB safety limit; the limit is not caller-configurable.
@@ -59,6 +68,7 @@ EXAMPLES = r"""
 - name: Persist an immutable encrypted bootstrap document
   lit.foundational.ansible_vault_document:
     path: /secure/inventory/bootstrap/service01.vault.yml
+    vault_id: production
     document:
       schema_version: 1
       subject: service01.example.test

--- a/roles/luks_header_escrow/README.md
+++ b/roles/luks_header_escrow/README.md
@@ -1,0 +1,98 @@
+# lit.foundational.luks_header_escrow
+
+Persist the sole installed LUKS2 header declared by `crypttab` as an immutable,
+controller-side Ansible Vault document. Raw header bytes exist only in a
+protected temporary directory on the managed host and protected Ansible memory;
+they are never written as controller plaintext.
+
+## Requirements
+
+- A Linux managed host with exactly one active `crypttab` source.
+- `cryptsetup`, `findfs`, `readlink`, `id`, `awk`, and Bash at the declared absolute paths.
+- Privilege to read and back up the installed LUKS2 header.
+- An Ansible Vault identity already loaded by the controller. Select its label
+  with `luks_header_escrow_vault_id`; the role never accepts password material.
+- An existing, non-symlinked `0700` escrow root owned by the effective
+  controller user, with the normalized absolute escrow path below it.
+- Durable controller storage. In AAP, mount the escrow root into the execution
+  environment from persistent, separately backed-up storage; job-local project
+  and container filesystems are ephemeral and are not valid escrow targets.
+
+The enabled role intentionally refuses check mode. Callers should also enforce
+their own fleet-selection, operating-system, lifecycle-phase, and confirmation
+policy before invoking it.
+
+## Variables
+
+See `defaults/main.yml` for the complete interface. Important inputs are:
+
+- `luks_header_escrow_enabled`: explicit opt-in; defaults to `false`.
+- `luks_header_escrow_path`: absolute controller ciphertext path.
+- `luks_header_escrow_controller_root_path`: allowed canonical controller root.
+- `luks_header_escrow_vault_id`: loaded Ansible Vault identity label used when
+  creating an absent ciphertext document; it may contain only ASCII letters,
+  digits, dots, underscores, and hyphens, and defaults to `default`.
+- `luks_header_escrow_schema_version`: immutable document schema; currently `1`.
+- `luks_header_escrow_max_raw_bytes`: approved raw-header ceiling, capped at 20 MiB.
+- `luks_header_escrow_subject`: document subject; defaults to `inventory_hostname`.
+- `luks_header_escrow_crypttab_path`: managed-host `crypttab` path.
+- `luks_header_escrow_cryptsetup_path`: absolute `cryptsetup` path.
+- `luks_header_escrow_remote_temporary_root`: protected managed-host temporary root.
+- `luks_header_escrow_allow_regular_file_device`: test/lab-only opt-in for a
+  regular-file LUKS2 source; production defaults require a canonical block device.
+
+The managed-host temporary root must already be canonical, owned by the
+effective execution user, grant that owner `rwx`, and deny group/other write
+access. Every ancestor back to `/` must be owned by root or that user and either
+deny group/other writes or use sticky-directory protection. The role validates
+the allocated `0700` directory and binds the transferred base64 payload to the
+remotely inspected byte size and SHA-256 before any immutable ciphertext is
+published.
+
+On success, `luks_header_escrow_result` contains only safe metadata: whether
+ciphertext was created, existence, path, ciphertext SHA-256, and LUKS UUID. It
+never contains the header or the plaintext escrow document.
+
+The `preflight` task entrypoint validates the same role interface plus
+controller path, ownership, and permission policy without contacting the
+managed host.
+
+The role captures and verifies an immutable header document; it does not restore
+a header, rotate LUKS keys, prune escrow, or replace the required independent
+backup and recovery procedure. Loss of the sole ciphertext or its Vault identity
+makes this escrow unusable, so back up and recovery-test both separately.
+
+## Dependencies
+
+None. The role uses `lit.foundational.ansible_vault_document` from this
+collection for atomic create-if-absent encryption and exact immutable readback.
+
+## Example Playbook
+
+```yaml
+---
+- name: Escrow one installed LUKS2 header
+  hosts: encrypted_linux
+  gather_facts: false
+  become: true
+  serial: 1
+
+  roles:
+    - role: lit.foundational.luks_header_escrow
+      vars:
+        luks_header_escrow_enabled: true
+        # Pre-create and mount this 0700 directory from durable controller storage.
+        luks_header_escrow_controller_root_path: /mnt/ansible-escrow
+        luks_header_escrow_path: >-
+          {{ '/mnt/ansible-escrow/luks-headers/'
+             ~ inventory_hostname ~ '.vault.yml' }}
+        luks_header_escrow_vault_id: production
+```
+
+## License
+
+MIT
+
+## Author
+
+Lightning IT

--- a/roles/luks_header_escrow/defaults/main.yml
+++ b/roles/luks_header_escrow/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+luks_header_escrow_enabled: false
+luks_header_escrow_schema_version: 1
+luks_header_escrow_max_raw_bytes: 20971520
+luks_header_escrow_path: ""
+luks_header_escrow_subject: "{{ inventory_hostname }}"
+
+luks_header_escrow_controller_root_path: ""
+luks_header_escrow_vault_id: default
+
+luks_header_escrow_crypttab_path: /etc/crypttab
+luks_header_escrow_awk_path: /usr/bin/awk
+luks_header_escrow_findfs_path: /usr/sbin/findfs
+luks_header_escrow_readlink_path: /usr/bin/readlink
+luks_header_escrow_id_path: /usr/bin/id
+luks_header_escrow_cryptsetup_path: /usr/sbin/cryptsetup
+luks_header_escrow_bash_path: /bin/bash
+luks_header_escrow_remote_temporary_root: /run
+luks_header_escrow_allow_regular_file_device: false

--- a/roles/luks_header_escrow/meta/argument_specs.yml
+++ b/roles/luks_header_escrow/meta/argument_specs.yml
@@ -1,0 +1,73 @@
+---
+argument_specs:
+  main:
+    short_description: Persist one installed LUKS2 header as immutable Ansible Vault ciphertext.
+    options: &luks_header_escrow_options
+      luks_header_escrow_enabled:
+        type: bool
+        default: false
+        description: Whether to capture and persist the installed LUKS2 header.
+      luks_header_escrow_schema_version:
+        type: int
+        default: 1
+        description: Immutable controller document schema version.
+      luks_header_escrow_max_raw_bytes:
+        type: int
+        default: 20971520
+        description: Maximum accepted raw LUKS-header size in bytes.
+      luks_header_escrow_path:
+        type: path
+        default: ""
+        description: Absolute normalized controller ciphertext path.
+      luks_header_escrow_subject:
+        type: str
+        description: Stable subject recorded in the immutable document.
+      luks_header_escrow_controller_root_path:
+        type: path
+        default: ""
+        description: Canonical controller root that must contain the ciphertext path.
+      luks_header_escrow_vault_id:
+        type: str
+        default: default
+        description: >-
+          ASCII letter, digit, dot, underscore, or hyphen label of the Ansible
+          Vault identity already loaded on the controller.
+      luks_header_escrow_crypttab_path:
+        type: path
+        default: /etc/crypttab
+        description: Managed-host crypttab containing exactly one active source.
+      luks_header_escrow_awk_path:
+        type: path
+        default: /usr/bin/awk
+        description: Absolute managed-host awk executable path.
+      luks_header_escrow_findfs_path:
+        type: path
+        default: /usr/sbin/findfs
+        description: Absolute managed-host findfs executable path.
+      luks_header_escrow_readlink_path:
+        type: path
+        default: /usr/bin/readlink
+        description: Absolute managed-host readlink executable path used for canonical device resolution.
+      luks_header_escrow_id_path:
+        type: path
+        default: /usr/bin/id
+        description: Absolute managed-host id executable path used to resolve the effective user ID.
+      luks_header_escrow_cryptsetup_path:
+        type: path
+        default: /usr/sbin/cryptsetup
+        description: Absolute managed-host cryptsetup executable path.
+      luks_header_escrow_bash_path:
+        type: path
+        default: /bin/bash
+        description: Absolute managed-host Bash executable path.
+      luks_header_escrow_remote_temporary_root:
+        type: path
+        default: /run
+        description: Protected managed-host root for the ephemeral raw header.
+      luks_header_escrow_allow_regular_file_device:
+        type: bool
+        default: false
+        description: Permit a regular-file LUKS2 source for explicit test or lab use.
+  preflight:
+    short_description: Validate the LUKS-header escrow interface and controller state without contacting the host.
+    options: *luks_header_escrow_options

--- a/roles/luks_header_escrow/meta/main.yml
+++ b/roles/luks_header_escrow/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: luks_header_escrow
+  namespace: lit
+  author: Lightning IT
+  company: Lightning IT
+  description: Persist one installed LUKS2 header as immutable controller-side Ansible Vault ciphertext.
+  license: MIT
+  min_ansible_version: "2.18"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+  galaxy_tags:
+    - backup
+    - encryption
+    - linux
+    - luks
+    - security
+    - vault
+
+dependencies: []

--- a/roles/luks_header_escrow/tasks/assert.yml
+++ b/roles/luks_header_escrow/tasks/assert.yml
@@ -1,0 +1,50 @@
+---
+- name: Validate the LUKS-header escrow enablement contract
+  ansible.builtin.assert:
+    that:
+      - luks_header_escrow_enabled is boolean
+    fail_msg: "luks_header_escrow_enabled must be a boolean."
+    quiet: true
+
+- name: Validate enabled LUKS-header escrow inputs
+  ansible.builtin.assert:
+    that:
+      - luks_header_escrow_schema_version | type_debug == 'int'
+      - luks_header_escrow_schema_version == 1
+      - luks_header_escrow_max_raw_bytes | type_debug == 'int'
+      - luks_header_escrow_max_raw_bytes > 0
+      - luks_header_escrow_max_raw_bytes <= _luks_header_escrow_safe_raw_max_bytes
+      - luks_header_escrow_path is string
+      - luks_header_escrow_path | length > 0
+      - luks_header_escrow_path is match('^/')
+      - luks_header_escrow_subject is string
+      - luks_header_escrow_subject | trim | length > 0
+      - luks_header_escrow_controller_root_path is string
+      - luks_header_escrow_controller_root_path is match('^/')
+      - luks_header_escrow_vault_id is string
+      - luks_header_escrow_vault_id is match('^[A-Za-z0-9_.-]+$')
+      - luks_header_escrow_crypttab_path is string
+      - luks_header_escrow_crypttab_path is match('^/')
+      - luks_header_escrow_awk_path is string
+      - luks_header_escrow_awk_path is match('^/')
+      - luks_header_escrow_findfs_path is string
+      - luks_header_escrow_findfs_path is match('^/')
+      - luks_header_escrow_readlink_path is string
+      - luks_header_escrow_readlink_path is match('^/')
+      - luks_header_escrow_id_path is string
+      - luks_header_escrow_id_path is match('^/')
+      - luks_header_escrow_cryptsetup_path is string
+      - luks_header_escrow_cryptsetup_path is match('^/')
+      - luks_header_escrow_bash_path is string
+      - luks_header_escrow_bash_path is match('^/')
+      - luks_header_escrow_remote_temporary_root is string
+      - luks_header_escrow_remote_temporary_root is match('^/')
+      - luks_header_escrow_allow_regular_file_device is boolean
+      - not ansible_check_mode
+    fail_msg: >-
+      Enabled LUKS-header escrow requires schema version 1, a safe positive
+      size ceiling, absolute controller and managed-host paths, a loaded Vault
+      identity label containing only ASCII letters, digits, dots, underscores,
+      and hyphens, a non-empty subject, and normal execution outside check mode.
+    quiet: true
+  when: luks_header_escrow_enabled | bool

--- a/roles/luks_header_escrow/tasks/controller_preflight.yml
+++ b/roles/luks_header_escrow/tasks/controller_preflight.yml
@@ -1,0 +1,60 @@
+---
+- name: Resolve canonical controller escrow paths
+  ansible.builtin.set_fact:
+    _luks_header_escrow_root_canonical: >-
+      {{ luks_header_escrow_controller_root_path | realpath }}
+    _luks_header_escrow_path_canonical: >-
+      {{ luks_header_escrow_path | realpath }}
+    _luks_header_escrow_path_normalized: >-
+      {{ luks_header_escrow_path | normpath }}
+  changed_when: false
+  no_log: true
+
+- name: Require the canonical escrow path below the controller root
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_root_canonical | length > 1
+      - _luks_header_escrow_path_normalized is match('^/')
+      - _luks_header_escrow_path_canonical != _luks_header_escrow_root_canonical
+      - >-
+        _luks_header_escrow_path_canonical.startswith(
+          _luks_header_escrow_root_canonical ~ '/'
+        )
+    fail_msg: >-
+      The canonical encrypted LUKS-header path must remain below the declared
+      controller escrow root.
+    quiet: true
+  no_log: true
+
+- name: Resolve the effective Ansible controller user ID
+  ansible.builtin.set_fact:
+    _luks_header_escrow_controller_uid: >-
+      {{ lookup('ansible.builtin.pipe', 'id -u') | int }}
+  changed_when: false
+  no_log: true
+
+- name: Inspect the declared controller escrow root
+  ansible.builtin.stat:
+    path: "{{ luks_header_escrow_controller_root_path }}"
+    follow: false
+  delegate_to: localhost
+  become: false
+  register: _luks_header_escrow_controller_root
+  changed_when: false
+  no_log: true
+
+- name: Require a private controller-owned escrow root
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_controller_root.stat.exists | default(false)
+      - _luks_header_escrow_controller_root.stat.isdir | default(false)
+      - not (_luks_header_escrow_controller_root.stat.islnk | default(false))
+      - _luks_header_escrow_controller_root.stat.mode | default('') == '0700'
+      - >-
+        _luks_header_escrow_controller_root.stat.uid | default(-1) | int
+        == _luks_header_escrow_controller_uid | int
+    fail_msg: >-
+      The controller escrow root must already exist as a non-symlinked 0700
+      directory owned by the effective Ansible controller user.
+    quiet: true
+  no_log: true

--- a/roles/luks_header_escrow/tasks/discover.yml
+++ b/roles/luks_header_escrow/tasks/discover.yml
@@ -1,0 +1,110 @@
+---
+- name: Read active crypttab source declarations
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_awk_path }}"
+      - '!/^[[:space:]]*#/ && NF >= 2 {print $2}'
+      - "{{ luks_header_escrow_crypttab_path }}"
+  register: _luks_header_escrow_crypttab_sources
+  changed_when: false
+  no_log: true
+
+- name: Require exactly one encrypted source declaration
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_crypttab_sources.stdout_lines | length == 1
+      - _luks_header_escrow_crypttab_sources.stdout_lines[0] | trim | length > 0
+    fail_msg: "Expected exactly one active crypttab source declaration."
+    quiet: true
+  no_log: true
+
+- name: Resolve the encrypted source device
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_findfs_path }}"
+      - "{{ _luks_header_escrow_crypttab_sources.stdout_lines[0] }}"
+  register: _luks_header_escrow_findfs
+  changed_when: false
+  no_log: true
+
+- name: Canonicalize the encrypted source device on the managed host
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_readlink_path }}"
+      - --canonicalize-existing
+      - "{{ _luks_header_escrow_findfs.stdout | trim }}"
+  register: _luks_header_escrow_device_canonical
+  changed_when: false
+  no_log: true
+
+- name: Require one canonical device below dev
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_findfs.stdout_lines | length == 1
+      - _luks_header_escrow_device_canonical.stdout_lines | length == 1
+      - _luks_header_escrow_device_canonical.stdout | trim is match('^/dev/')
+    fail_msg: "The sole crypttab source must resolve canonically below /dev."
+    quiet: true
+  no_log: true
+
+- name: Inspect the canonical encrypted source device
+  ansible.builtin.stat:
+    path: "{{ _luks_header_escrow_device_canonical.stdout | trim }}"
+    follow: false
+    get_checksum: false
+    get_mime: false
+  register: _luks_header_escrow_device_stat
+  changed_when: false
+  no_log: true
+
+- name: Require a block device unless regular-file mode is explicitly enabled
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_device_stat.stat.exists | default(false)
+      - not (_luks_header_escrow_device_stat.stat.islnk | default(false))
+      - >-
+        _luks_header_escrow_device_stat.stat.isblk | default(false)
+        or (
+          luks_header_escrow_allow_regular_file_device | bool
+          and _luks_header_escrow_device_stat.stat.isreg | default(false)
+        )
+    fail_msg: >-
+      The canonical crypttab source must be a block device. Regular-file LUKS
+      sources require the explicit test/lab opt-in.
+    quiet: true
+  no_log: true
+
+- name: Record the canonical encrypted source device
+  ansible.builtin.set_fact:
+    _luks_header_escrow_device: >-
+      {{ _luks_header_escrow_device_canonical.stdout | trim }}
+  changed_when: false
+  no_log: true
+
+- name: Require installed LUKS2 JSON metadata
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_cryptsetup_path }}"
+      - luksDump
+      - --dump-json-metadata
+      - "{{ _luks_header_escrow_device }}"
+  changed_when: false
+  no_log: true
+
+- name: Read the installed LUKS UUID
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_cryptsetup_path }}"
+      - luksUUID
+      - "{{ _luks_header_escrow_device }}"
+  register: _luks_header_escrow_uuid
+  changed_when: false
+  no_log: true
+
+- name: Require a non-empty installed LUKS UUID
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_uuid.stdout | trim | length > 0
+    fail_msg: "The installed LUKS2 source did not return a UUID."
+    quiet: true
+  no_log: true

--- a/roles/luks_header_escrow/tasks/escrow.yml
+++ b/roles/luks_header_escrow/tasks/escrow.yml
@@ -1,0 +1,271 @@
+---
+- name: Create, encrypt, and verify the independent LUKS-header escrow
+  block:
+    - name: Allocate a protected remote header directory
+      ansible.builtin.tempfile:
+        state: directory
+        path: "{{ luks_header_escrow_remote_temporary_root }}"
+        prefix: "{{ _luks_header_escrow_remote_temporary_prefix }}"
+      register: _luks_header_escrow_temp
+      changed_when: false
+      no_log: true
+
+    - name: Canonicalize the allocated remote header directory
+      ansible.builtin.command:
+        argv:
+          - "{{ luks_header_escrow_readlink_path }}"
+          - --canonicalize-existing
+          - "{{ _luks_header_escrow_temp.path }}"
+      register: _luks_header_escrow_temp_canonical
+      changed_when: false
+      no_log: true
+
+    - name: Inspect the allocated remote header directory
+      ansible.builtin.stat:
+        path: "{{ _luks_header_escrow_temp.path }}"
+        follow: false
+        get_checksum: false
+        get_mime: false
+      register: _luks_header_escrow_temp_stat
+      changed_when: false
+      no_log: true
+
+    - name: Require a private canonical remote header directory
+      ansible.builtin.assert:
+        that:
+          - _luks_header_escrow_temp_canonical.stdout_lines | length == 1
+          - >-
+            _luks_header_escrow_temp_canonical.stdout | trim
+            == _luks_header_escrow_temp.path
+          - >-
+            _luks_header_escrow_temp.path | dirname
+            == _luks_header_escrow_remote_root_canonical
+          - _luks_header_escrow_temp_stat.stat.exists | default(false)
+          - _luks_header_escrow_temp_stat.stat.isdir | default(false)
+          - not (_luks_header_escrow_temp_stat.stat.islnk | default(false))
+          - _luks_header_escrow_temp_stat.stat.mode | default('') == '0700'
+          - >-
+            _luks_header_escrow_temp_stat.stat.uid | default(-1) | int
+            == _luks_header_escrow_remote_uid | int
+        fail_msg: >-
+          The allocated remote LUKS-header directory is not a private,
+          canonical 0700 directory owned by the effective managed-host user.
+        quiet: true
+      no_log: true
+
+    - name: Resolve the initially absent raw header path
+      ansible.builtin.set_fact:
+        _luks_header_escrow_raw_path: >-
+          {{ _luks_header_escrow_temp_canonical.stdout | trim }}/header.luks
+      changed_when: false
+      no_log: true
+
+    - name: Back up the raw LUKS2 header on the managed host
+      ansible.builtin.command:
+        argv:
+          - "{{ luks_header_escrow_bash_path }}"
+          - -c
+          - >-
+            umask 077;
+            exec "$1" luksHeaderBackup "$2" --header-backup-file "$3"
+          - lit-luks-header-backup
+          - "{{ luks_header_escrow_cryptsetup_path }}"
+          - "{{ _luks_header_escrow_device }}"
+          - "{{ _luks_header_escrow_raw_path }}"
+      changed_when: false
+      no_log: true
+
+    - name: Read the backup LUKS UUID
+      ansible.builtin.command:
+        argv:
+          - "{{ luks_header_escrow_cryptsetup_path }}"
+          - luksUUID
+          - "{{ _luks_header_escrow_raw_path }}"
+      register: _luks_header_escrow_backup_uuid
+      changed_when: false
+      no_log: true
+
+    - name: Require backup LUKS2 JSON metadata
+      ansible.builtin.command:
+        argv:
+          - "{{ luks_header_escrow_cryptsetup_path }}"
+          - luksDump
+          - --dump-json-metadata
+          - "{{ _luks_header_escrow_raw_path }}"
+      changed_when: false
+      no_log: true
+
+    - name: Require the backup to match the installed LUKS2 UUID
+      ansible.builtin.assert:
+        that:
+          - >-
+            _luks_header_escrow_backup_uuid.stdout | trim
+            == _luks_header_escrow_uuid.stdout | trim
+        fail_msg: "The remote LUKS-header backup UUID does not match."
+        quiet: true
+      no_log: true
+
+    - name: Calculate raw header size and SHA-256 on the managed host
+      ansible.builtin.stat:
+        path: "{{ _luks_header_escrow_raw_path }}"
+        get_checksum: true
+        checksum_algorithm: sha256
+      register: _luks_header_escrow_raw_stat
+      changed_when: false
+      no_log: true
+
+    - name: Require a protected header below the safe encrypted envelope
+      ansible.builtin.assert:
+        that:
+          - _luks_header_escrow_raw_stat.stat.exists | default(false)
+          - _luks_header_escrow_raw_stat.stat.isreg | default(false)
+          - not (_luks_header_escrow_raw_stat.stat.islnk | default(false))
+          - _luks_header_escrow_raw_stat.stat.mode | default('') == '0400'
+          - >-
+            _luks_header_escrow_raw_stat.stat.uid | default(-1) | int
+            == _luks_header_escrow_remote_uid | int
+          - _luks_header_escrow_raw_stat.stat.nlink | default(0) | int == 1
+          - _luks_header_escrow_raw_stat.stat.size | default(0) | int > 0
+          - >-
+            _luks_header_escrow_raw_stat.stat.size | int
+            <= luks_header_escrow_max_raw_bytes
+          - >-
+            _luks_header_escrow_raw_stat.stat.checksum | default('')
+            is match('^[0-9a-f]{64}$')
+        fail_msg: >-
+          The remote LUKS-header backup is absent, invalid, insufficiently
+          protected, or too large for the approved encrypted envelope.
+        quiet: true
+      no_log: true
+
+    - name: Read the raw header as base64 into protected Ansible memory
+      ansible.builtin.slurp:
+        src: "{{ _luks_header_escrow_raw_path }}"
+      register: _luks_header_escrow_slurp
+      no_log: true
+
+    - name: Bind the protected payload to its inspected size and SHA-256
+      ansible.builtin.assert:
+        that:
+          - _luks_header_escrow_slurp.content is string
+          - >-
+            _luks_header_escrow_slurp.content | length
+            == (((_luks_header_escrow_raw_stat.stat.size | int) + 2) // 3) * 4
+          - >-
+            _luks_header_escrow_slurp.content | b64decode | hash('sha256')
+            == _luks_header_escrow_raw_stat.stat.checksum
+        fail_msg: >-
+          The protected raw header payload changed between managed-host
+          inspection and its single transfer into Ansible memory.
+        quiet: true
+      no_log: true
+
+    - name: Immediately remove the remote raw LUKS-header directory
+      ansible.builtin.file:
+        path: "{{ _luks_header_escrow_temp.path }}"
+        state: absent
+      changed_when: false
+      no_log: true
+
+    - name: Build the exact immutable escrow document
+      ansible.builtin.set_fact:
+        _luks_header_escrow_document: >-
+          {{
+            {
+              'schema_version': luks_header_escrow_schema_version,
+              'subject': luks_header_escrow_subject,
+              'luks_format': 'luks2',
+              'luks_uuid': _luks_header_escrow_uuid.stdout | trim,
+              'luks_header_b64': _luks_header_escrow_slurp.content,
+              'luks_header_raw_size_bytes':
+                _luks_header_escrow_raw_stat.stat.size | int,
+              'luks_header_sha256_raw':
+                _luks_header_escrow_raw_stat.stat.checksum
+            }
+          }}
+      changed_when: false
+      no_log: true
+
+    - name: Persist the immutable encrypted controller escrow
+      lit.foundational.ansible_vault_document:
+        path: "{{ _luks_header_escrow_path_normalized }}"
+        document: "{{ _luks_header_escrow_document }}"
+        vault_id: "{{ luks_header_escrow_vault_id }}"
+      register: _luks_header_escrow_write
+      no_log: true
+
+    - name: Read back and require the exact encrypted document
+      lit.foundational.ansible_vault_document:
+        path: "{{ _luks_header_escrow_path_normalized }}"
+        document: "{{ _luks_header_escrow_document }}"
+        vault_id: "{{ luks_header_escrow_vault_id }}"
+      register: _luks_header_escrow_verified
+      no_log: true
+
+    - name: Require immutable ciphertext readback without disclosure
+      ansible.builtin.assert:
+        that:
+          - _luks_header_escrow_write.exists | default(false)
+          - _luks_header_escrow_verified.exists | default(false)
+          - not (_luks_header_escrow_verified.created | default(false) | bool)
+          - not (_luks_header_escrow_verified.changed | default(false) | bool)
+          - >-
+            _luks_header_escrow_write.ciphertext_sha256
+            == _luks_header_escrow_verified.ciphertext_sha256
+          - >-
+            _luks_header_escrow_verified.path
+            == _luks_header_escrow_path_normalized
+          - >-
+            _luks_header_escrow_verified.ciphertext_sha256 | default('')
+            is match('^[0-9a-f]{64}$')
+        fail_msg: >-
+          The encrypted controller LUKS-header escrow did not pass exact
+          immutable readback verification.
+        quiet: true
+      no_log: true
+
+    - name: Publish secret-free LUKS-header escrow results
+      ansible.builtin.set_fact:
+        luks_header_escrow_result: >-
+          {{
+            {
+              'created':
+                _luks_header_escrow_write.created | default(false) | bool,
+              'exists': true,
+              'path': _luks_header_escrow_verified.path,
+              'ciphertext_sha256':
+                _luks_header_escrow_verified.ciphertext_sha256,
+              'luks_uuid': _luks_header_escrow_uuid.stdout | trim
+            }
+          }}
+        cacheable: false
+      changed_when: false
+      no_log: true
+
+  always:
+    - name: Remove the raw remote LUKS-header directory
+      ansible.builtin.file:
+        path: "{{ _luks_header_escrow_temp.path }}"
+        state: absent
+      when:
+        - _luks_header_escrow_temp is defined
+        - _luks_header_escrow_temp.path is defined
+      changed_when: false
+      no_log: true
+
+    - name: Clear sensitive LUKS-header variables from active facts
+      ansible.builtin.set_fact:
+        _luks_header_escrow_document: null
+        _luks_header_escrow_slurp: null
+        _luks_header_escrow_raw_stat: null
+        _luks_header_escrow_raw_path: null
+        _luks_header_escrow_temp_canonical: null
+        _luks_header_escrow_temp_stat: null
+      changed_when: false
+      no_log: true
+
+- name: Report verified independent LUKS-header escrow
+  ansible.builtin.debug:
+    msg: >-
+      LUKS2 header ciphertext exists at the declared controller escrow path
+      and passed exact immutable readback verification.

--- a/roles/luks_header_escrow/tasks/main.yml
+++ b/roles/luks_header_escrow/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Validate controller escrow state
+  ansible.builtin.import_tasks: controller_preflight.yml
+  when: luks_header_escrow_enabled | bool
+  tags: always
+
+- name: Validate managed-host temporary state
+  ansible.builtin.import_tasks: remote_preflight.yml
+  when: luks_header_escrow_enabled | bool
+
+- name: Discover the installed LUKS2 source
+  ansible.builtin.import_tasks: discover.yml
+  when: luks_header_escrow_enabled | bool
+
+- name: Persist the installed LUKS2 header escrow
+  ansible.builtin.import_tasks: escrow.yml
+  when: luks_header_escrow_enabled | bool

--- a/roles/luks_header_escrow/tasks/preflight.yml
+++ b/roles/luks_header_escrow/tasks/preflight.yml
@@ -1,0 +1,9 @@
+---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Validate controller escrow state
+  ansible.builtin.import_tasks: controller_preflight.yml
+  when: luks_header_escrow_enabled | bool
+  tags: always

--- a/roles/luks_header_escrow/tasks/remote_preflight.yml
+++ b/roles/luks_header_escrow/tasks/remote_preflight.yml
@@ -1,0 +1,139 @@
+---
+- name: Resolve the effective managed-host user ID
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_id_path }}"
+      - -u
+  register: _luks_header_escrow_remote_uid_command
+  changed_when: false
+  no_log: true
+
+- name: Canonicalize the managed-host temporary root
+  ansible.builtin.command:
+    argv:
+      - "{{ luks_header_escrow_readlink_path }}"
+      - --canonicalize-existing
+      - "{{ luks_header_escrow_remote_temporary_root }}"
+  register: _luks_header_escrow_remote_root_command
+  changed_when: false
+  no_log: true
+
+- name: Inspect the managed-host temporary root
+  ansible.builtin.stat:
+    path: "{{ luks_header_escrow_remote_temporary_root }}"
+    follow: false
+    get_checksum: false
+    get_mime: false
+  register: _luks_header_escrow_remote_root_stat
+  changed_when: false
+  no_log: true
+
+- name: Require a canonical managed-host temporary root contract
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_remote_uid_command.stdout_lines | length == 1
+      - >-
+        _luks_header_escrow_remote_uid_command.stdout | trim
+        is match('^[0-9]+$')
+      - _luks_header_escrow_remote_root_command.stdout_lines | length == 1
+      - >-
+        _luks_header_escrow_remote_root_command.stdout | trim
+        == luks_header_escrow_remote_temporary_root
+    fail_msg: >-
+      The managed-host temporary root and effective user ID must resolve to
+      single canonical values before path ancestry can be validated.
+    quiet: true
+  no_log: true
+
+- name: Initialize managed-host temporary-root ancestry
+  ansible.builtin.set_fact:
+    _luks_header_escrow_remote_ancestry:
+      - /
+  changed_when: false
+  no_log: true
+
+- name: Build managed-host temporary-root ancestry
+  ansible.builtin.set_fact:
+    _luks_header_escrow_remote_ancestry: >-
+      {{
+        _luks_header_escrow_remote_ancestry
+        + [
+            (
+              (_luks_header_escrow_remote_ancestry | last)
+              ~ '/' ~ item
+            ) | normpath
+          ]
+      }}
+  loop: >-
+    {{
+      (_luks_header_escrow_remote_root_command.stdout | trim).split('/')
+      | reject('equalto', '')
+      | list
+    }}
+  changed_when: false
+  no_log: true
+
+- name: Inspect managed-host temporary-root parent ancestry
+  ansible.builtin.stat:
+    path: "{{ item }}"
+    follow: false
+    get_checksum: false
+    get_mime: false
+  loop: "{{ _luks_header_escrow_remote_ancestry[:-1] }}"
+  register: _luks_header_escrow_remote_ancestry_stat
+  changed_when: false
+  no_log: true
+
+- name: Require protected managed-host temporary-root ancestry
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists | default(false)
+      - item.stat.isdir | default(false)
+      - not (item.stat.islnk | default(false))
+      - >-
+        item.stat.uid | default(-1) | int
+        in [0, _luks_header_escrow_remote_uid_command.stdout | trim | int]
+      - >-
+        (
+          item.stat.mode | default('')
+          is match('^[0-7][0-7][0145][0145]$')
+        ) or (
+          item.stat.mode | default('')
+          is match('^[1357][0-7][0-7][0-7]$')
+        )
+    fail_msg: >-
+      Every managed-host temporary-root ancestor must be a non-symlinked
+      directory owned by root or the effective user. Writable ancestors must
+      carry the sticky bit so an unprivileged user cannot replace a validated
+      child path.
+    quiet: true
+  loop: "{{ _luks_header_escrow_remote_ancestry_stat.results }}"
+  no_log: true
+
+- name: Require a protected managed-host temporary root
+  ansible.builtin.assert:
+    that:
+      - _luks_header_escrow_remote_root_stat.stat.exists | default(false)
+      - _luks_header_escrow_remote_root_stat.stat.isdir | default(false)
+      - not (_luks_header_escrow_remote_root_stat.stat.islnk | default(false))
+      - >-
+        _luks_header_escrow_remote_root_stat.stat.uid | default(-1) | int
+        == _luks_header_escrow_remote_uid_command.stdout | trim | int
+      - >-
+        _luks_header_escrow_remote_root_stat.stat.mode | default('')
+        is match('^07[0145][0145]$')
+    fail_msg: >-
+      The managed-host temporary root must be a canonical, non-symlinked
+      directory owned by the effective user, with owner rwx access and no
+      group or other write permission.
+    quiet: true
+  no_log: true
+
+- name: Record validated managed-host temporary state
+  ansible.builtin.set_fact:
+    _luks_header_escrow_remote_uid: >-
+      {{ _luks_header_escrow_remote_uid_command.stdout | trim | int }}
+    _luks_header_escrow_remote_root_canonical: >-
+      {{ _luks_header_escrow_remote_root_command.stdout | trim }}
+  changed_when: false
+  no_log: true

--- a/roles/luks_header_escrow/vars/main.yml
+++ b/roles/luks_header_escrow/vars/main.yml
@@ -1,0 +1,3 @@
+---
+_luks_header_escrow_safe_raw_max_bytes: 20971520
+_luks_header_escrow_remote_temporary_prefix: lit-luks-header-escrow-

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,1 @@
+scripts/generate-release-evidence.py shebang

--- a/tests/unit/plugins/action/test_ansible_vault_document.py
+++ b/tests/unit/plugins/action/test_ansible_vault_document.py
@@ -16,6 +16,7 @@ from plugins.action import ansible_vault_secret_document as secret_plugin
 
 
 TEST_VAULT_PASSWORD = b"unit-test-only-vault-password"
+SECOND_VAULT_PASSWORD = b"unit-test-only-second-vault-password"
 SECRET_SENTINEL = "unit-test-only-root-token-must-not-leak"
 
 
@@ -74,6 +75,44 @@ def test_exact_document_is_created_once_and_rerun_is_unchanged(tmp_path, vault):
     assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
     assert yaml.safe_load(vault.decrypt(path.read_bytes())) == _document()
     assert SECRET_SENTINEL not in repr(created)
+
+
+def test_explicit_vault_id_selects_exactly_one_loaded_identity(tmp_path):
+    path = tmp_path / "private" / "selected.vault.yml"
+    selected_secret = VaultSecret(SECOND_VAULT_PASSWORD)
+    vault = VaultLib(
+        [
+            ("primary", VaultSecret(TEST_VAULT_PASSWORD)),
+            ("secondary", selected_secret),
+        ]
+    )
+
+    vault_secret, vault_id = plugin._select_vault_secret(vault, "secondary")
+    result = _store(vault).ensure_exact(
+        str(path),
+        _document(),
+        vault_secret=vault_secret,
+        vault_id=vault_id,
+    )
+
+    assert result["created"] is True
+    assert path.read_bytes().splitlines()[0] == b"$ANSIBLE_VAULT;1.2;AES256;secondary"
+    selected_vault = VaultLib([("secondary", selected_secret)])
+    assert yaml.safe_load(selected_vault.decrypt(path.read_bytes())) == _document()
+
+
+def test_explicit_vault_id_must_match_one_loaded_identity():
+    duplicate_vault = VaultLib(
+        [
+            ("duplicate", VaultSecret(TEST_VAULT_PASSWORD)),
+            ("duplicate", VaultSecret(SECOND_VAULT_PASSWORD)),
+        ]
+    )
+
+    with pytest.raises(AnsibleActionFail):
+        plugin._select_vault_secret(duplicate_vault, "missing")
+    with pytest.raises(AnsibleActionFail):
+        plugin._select_vault_secret(duplicate_vault, "duplicate")
 
 
 def test_ansible_unsafe_strings_are_normalized_to_exact_builtin_strings(
@@ -354,6 +393,55 @@ def test_argument_validation_rejects_password_relative_and_noncanonical_paths():
         plugin._normalize_arguments(
             {"path": "/secure/../document.vault.yml", "document": {}}
         )
+    normalized = plugin._normalize_arguments(
+        {
+            "path": "/secure/document.vault.yml",
+            "document": {},
+            "vault_id": "production",
+        }
+    )
+    assert normalized["vault_id"] == "production"
+
+
+@pytest.mark.parametrize(
+    "vault_id",
+    (
+        "",
+        "ümlaut",
+        "bad;identity",
+        "bad identity",
+        " leading",
+        "trailing ",
+        "bad\nidentity",
+    ),
+)
+def test_invalid_vault_id_fails_before_path_creation(tmp_path, vault_id):
+    path = tmp_path / "must-not-exist" / "document.vault.yml"
+
+    with pytest.raises(AnsibleActionFail):
+        plugin._normalize_arguments(
+            {
+                "path": str(path),
+                "document": {},
+                "vault_id": vault_id,
+            }
+        )
+
+    assert not path.parent.exists()
+
+
+def test_generated_ciphertext_is_validated_before_publication(
+    tmp_path,
+    vault,
+    monkeypatch,
+):
+    path = tmp_path / "must-not-exist" / "document.vault.yml"
+    monkeypatch.setattr(vault, "encrypt", lambda *args, **kwargs: b"not-vault-ciphertext")
+
+    with pytest.raises(AnsibleActionFail):
+        _store(vault).ensure_exact(str(path), _document())
+
+    assert not path.parent.exists()
 
 
 def test_task_no_log_is_required_and_failure_is_suppressed():


### PR DESCRIPTION
## Summary

- add lit.foundational.luks_header_escrow for immutable controller-side Ansible Vault escrow of one installed LUKS2 header
- extend ansible_vault_document with explicit already-loaded Vault identity selection and pre-publication ciphertext validation
- add full role documentation, argument specs, changelog, unit coverage, and a dedicated Molecule scenario

## Security properties

- no Vault password argument and no controller plaintext file
- canonical block-device validation; regular files require an explicit lab-only opt-in
- protected controller root plus complete managed-host temporary-path ancestry, owner, mode, symlink, and link-count validation
- transferred binary payload is bound to its inspected byte size and SHA-256 before atomic immutable ciphertext publication
- raw managed-host header directory is removed immediately after transfer and again in an always cleanup path

## Validation

- pre-commit run --all-files: passed (all 17 light Molecule scenarios and every lint/build hook)
- 60 unit tests: passed
- ansible-test sanity: passed all 34 sanity checks across Python 3.9-3.14
- focused luks-header-escrow-basic: converge, changed=0 idempotence, exact payload/UUID/size/SHA, eight expected refusal paths, cleanup: passed
- independent security and functional reviews: clean