### PR TITLE
fix: allow ansible.posix 2.1 compatibility

### DIFF
--- a/changelogs/fragments/ansible-posix-21-compat.yml
+++ b/changelogs/fragments/ansible-posix-21-compat.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - collection - Lower the declared ``ansible.posix`` minimum to 2.1.0 so the collection can be resolved alongside
+    ``fedora.linux_system_roles`` 1.127.2, which requires ``ansible.posix`` below 2.2.0.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,7 +20,7 @@ dependencies:
   community.hrobot: 2.7.2
   community.general: '>=11.4.9,<12.0.0'
   community.crypto: '>=3.2.2,<4.0.0'
-  ansible.posix: '>=2.2.0'
+  ansible.posix: '>=2.1.0'
   community.docker: '*'
   community.vmware: 5.10.0
   vmware.vmware: '>=2.9.0'


### PR DESCRIPTION
## Summary

- lower the declared `ansible.posix` minimum from 2.2.0 to 2.1.0
- restore compatibility with `fedora.linux_system_roles` 1.127.2 (`ansible.posix >=2.1.0,<2.2.0`)
- document the resolver compatibility correction in the collection changelog

Repository-wide inspection confirms this collection does not call any `ansible.posix.*` module or plugin, so it consumes no API introduced in 2.2.

## Verification

- `pre-commit run --all-files` (all hooks passed using the managed execution environment)
- production ansible-lint and changelog policy passed
- all 17 non-heavy Molecule scenarios passed
- collection build/install smoke and Galaxy role verification passed
- isolated local artifact graph installed with exact `ansible.posix` 2.1.0 and `fedora.linux_system_roles` 1.127.2
- all 61 role task module FQCNs (38 collection-provided) resolved with system-path collection scanning disabled
- isolated artifact SHA-256: `e7ba43a142ba7255c39e6c96e01ee0d4a5071f4aba80fcc20ccf86b6d910391d`