### PR TITLE
chore: sync final Copilot review gate

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -97,6 +97,7 @@ jobs:
           ) {
             node(id: $review) {
               ... on PullRequestReview {
+                body
                 commit { oid }
                 pullRequest { headRefOid }
                 comments(first: 100, after: $after) {
@@ -109,7 +110,8 @@ jobs:
           GRAPHQL
 
           review_comments_clean() {
-            local review_id="$1" expected_head="$2" after="" response has_next marker_count
+            local review_id="$1" expected_head="$2" after="" response has_next
+            local marker_count content_count meaningful_content=false
             local -a arguments
             while true; do
               arguments=(
@@ -133,27 +135,41 @@ jobs:
                 return 2
               fi
 
-              marker_count="$(
-                jq \
+              read -r marker_count content_count <<<"$(
+                jq -r \
                   --arg marker "${normalized_unable_review_marker}" \
-                  '[
-                    .data.node.comments.nodes[]?
-                    | select(
-                        ((.body // "")
-                        | ascii_downcase
-                        | gsub("\\s"; "")
-                        | contains($marker))
-                      )
+                  'def review_content:
+                      (.data.node.body // ""),
+                      (.data.node.comments.nodes[]?.body // "");
+                  [
+                    ([
+                      review_content
+                      | select(
+                          ascii_downcase
+                          | gsub("\\s"; "")
+                          | contains($marker)
+                        )
+                    ] | length),
+                    ([
+                      review_content
+                      | select((gsub("\\s"; "")) != "")
+                    ] | length)
                   ]
-                  | length' <<<"${response}"
+                  | @tsv' <<<"${response}"
               )"
               if [ "${marker_count}" -gt 0 ]; then
                 return 1
               fi
+              if [ "${content_count}" -gt 0 ]; then
+                meaningful_content=true
+              fi
 
               has_next="$(jq -r '.data.node.comments.pageInfo.hasNextPage' <<<"${response}")"
               if [ "${has_next}" != "true" ]; then
-                return 0
+                if [ "${meaningful_content}" = true ]; then
+                  return 0
+                fi
+                return 1
               fi
               after="$(jq -r '.data.node.comments.pageInfo.endCursor // empty' <<<"${response}")"
               if [ -z "${after}" ]; then


### PR DESCRIPTION
Final narrow sync from `lightning-it/shared-assets-lit` after canonical PRs #288-#297. This updates only the fail-closed Copilot review gate; the PR remains draft until released into a bounded current-SHA review batch.