### PR TITLE
feat: increase ansible vault document capacity safely

### DIFF
--- a/changelogs/fragments/ansible-vault-document-bounded-large-escrow.yml
+++ b/changelogs/fragments/ansible-vault-document-bounded-large-escrow.yml
@@ -2,5 +2,6 @@
 minor_changes:
   - >-
     ansible_vault_document - separate the non-configurable document safety
-    bounds and raise them to 192 MiB for serialized plaintext and 512 MiB for
-    Ansible Vault ciphertext so bounded large recovery escrows can be persisted.
+    bounds, setting them to 126 MiB for serialized plaintext and 512 MiB for
+    Ansible Vault ciphertext, so bounded large recovery escrows fit within the
+    ciphertext envelope with a conservative margin.

--- a/changelogs/fragments/ansible-vault-document-bounded-large-escrow.yml
+++ b/changelogs/fragments/ansible-vault-document-bounded-large-escrow.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    ansible_vault_document - separate the non-configurable document safety
+    bounds and raise them to 192 MiB for serialized plaintext and 512 MiB for
+    Ansible Vault ciphertext so bounded large recovery escrows can be persisted.

--- a/plugins/action/ansible_vault_document.py
+++ b/plugins/action/ansible_vault_document.py
@@ -55,7 +55,8 @@ notes:
   - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
-  - Plaintext and ciphertext each have a fixed 128 MiB safety limit; the limit is not caller-configurable.
+  - Serialized plaintext has a fixed 192 MiB safety limit and ciphertext has a fixed 512 MiB safety limit.
+  - The safety limits are not caller-configurable.
   - Check mode validates an existing document. An absent document reports pending creation without creating a
     directory, serializing the mapping, or invoking Vault encryption.
 author:
@@ -96,7 +97,8 @@ ciphertext_sha256:
 
 
 _EXPECTED_ARGS = frozenset(("path", "document", "vault_id"))
-_MAX_DOCUMENT_BYTES = 128 * 1024 * 1024
+_MAX_PLAINTEXT_BYTES = 192 * 1024 * 1024
+_MAX_CIPHERTEXT_BYTES = 512 * 1024 * 1024
 _VAULT_ID_PATTERN = re.compile(r"[A-Za-z0-9_.-]+\Z", re.ASCII)
 
 
@@ -147,8 +149,8 @@ def _require_task_no_log(task):
 def _new_document_store(vault):
     return _VaultDocumentStore(
         vault,
-        max_ciphertext_bytes=_MAX_DOCUMENT_BYTES,
-        max_plaintext_bytes=_MAX_DOCUMENT_BYTES,
+        max_ciphertext_bytes=_MAX_CIPHERTEXT_BYTES,
+        max_plaintext_bytes=_MAX_PLAINTEXT_BYTES,
     )
 
 

--- a/plugins/action/ansible_vault_document.py
+++ b/plugins/action/ansible_vault_document.py
@@ -55,7 +55,8 @@ notes:
   - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
-  - Serialized plaintext has a fixed 192 MiB safety limit and ciphertext has a fixed 512 MiB safety limit.
+  - Serialized plaintext has a fixed 126 MiB safety limit and Ansible Vault ciphertext has a fixed 512 MiB safety limit.
+  - The plaintext limit includes a conservative margin for the Ansible Vault encoding envelope.
   - The safety limits are not caller-configurable.
   - Check mode validates an existing document. An absent document reports pending creation without creating a
     directory, serializing the mapping, or invoking Vault encryption.
@@ -97,7 +98,7 @@ ciphertext_sha256:
 
 
 _EXPECTED_ARGS = frozenset(("path", "document", "vault_id"))
-_MAX_PLAINTEXT_BYTES = 192 * 1024 * 1024
+_MAX_PLAINTEXT_BYTES = 126 * 1024 * 1024
 _MAX_CIPHERTEXT_BYTES = 512 * 1024 * 1024
 _VAULT_ID_PATTERN = re.compile(r"[A-Za-z0-9_.-]+\Z", re.ASCII)
 

--- a/plugins/modules/ansible_vault_document.py
+++ b/plugins/modules/ansible_vault_document.py
@@ -57,7 +57,8 @@ notes:
   - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
-  - Serialized plaintext has a fixed 192 MiB safety limit and ciphertext has a fixed 512 MiB safety limit.
+  - Serialized plaintext has a fixed 126 MiB safety limit and Ansible Vault ciphertext has a fixed 512 MiB safety limit.
+  - The plaintext limit includes a conservative margin for the Ansible Vault encoding envelope.
   - The safety limits are not caller-configurable.
   - Check mode never creates a directory, serializes the mapping, or invokes Vault encryption for an absent path.
 author:

--- a/plugins/modules/ansible_vault_document.py
+++ b/plugins/modules/ansible_vault_document.py
@@ -57,7 +57,8 @@ notes:
   - Set C(vault_id) when more than one identity is loaded so creation cannot silently use the wrong identity.
   - The action requires task-level C(no_log=true) to suppress secret task arguments at every callback verbosity.
   - Plaintext is serialized, encrypted, decrypted, and compared only in controller process memory.
-  - Plaintext and ciphertext each have a fixed 128 MiB safety limit; the limit is not caller-configurable.
+  - Serialized plaintext has a fixed 192 MiB safety limit and ciphertext has a fixed 512 MiB safety limit.
+  - The safety limits are not caller-configurable.
   - Check mode never creates a directory, serializes the mapping, or invokes Vault encryption for an absent path.
 author:
   - Lightning IT (@lightning-it)

--- a/tests/unit/plugins/action/test_ansible_vault_document.py
+++ b/tests/unit/plugins/action/test_ansible_vault_document.py
@@ -50,6 +50,17 @@ def _write_encrypted(path, vault, document):
     path.chmod(0o600)
 
 
+def _vault_envelope_size(plaintext_bytes, vault_id=None):
+    padded_plaintext = 16 * ((plaintext_bytes // 16) + 1)
+    encoded_payload = 2 * (64 + 1 + 64 + 1 + (2 * padded_plaintext))
+    if vault_id:
+        header = "$ANSIBLE_VAULT;1.2;AES256;{0}".format(vault_id)
+    else:
+        header = "$ANSIBLE_VAULT;1.1;AES256"
+    wrapped_lines = math.ceil(encoded_payload / 80)
+    return len(header.encode("ascii")) + encoded_payload + wrapped_lines + 1
+
+
 def test_exact_document_is_created_once_and_rerun_is_unchanged(tmp_path, vault):
     path = tmp_path / "private" / "service.vault.yml"
     store = _store(vault)
@@ -163,29 +174,72 @@ def test_generic_cap_supports_large_exact_documents_on_create_read_and_race_path
     assert rerun["changed"] is False
     assert race_digest == created["ciphertext_sha256"]
     assert store._max_ciphertext_bytes == 512 * 1024 * 1024
-    assert store._max_plaintext_bytes == 192 * 1024 * 1024
+    assert store._max_plaintext_bytes == 126 * 1024 * 1024
     with pytest.raises(AnsibleActionFail):
         secret_plugin._VaultSecretDocumentStore(vault).ensure_exact(str(path), document)
 
 
-def test_generic_fixed_ciphertext_cap_rejects_before_path_creation(
+@pytest.mark.parametrize("plaintext_size", (0, 1, 15, 16, 17, 79, 80, 81, 1024))
+def test_vault_envelope_formula_matches_real_vault_output(vault, plaintext_size):
+    plaintext = b"A" * plaintext_size
+
+    assert len(vault.encrypt(plaintext)) == _vault_envelope_size(plaintext_size)
+    assert len(vault.encrypt(plaintext, vault_id="unit-test")) == _vault_envelope_size(
+        plaintext_size,
+        vault_id="unit-test",
+    )
+
+
+def test_configured_plaintext_cap_fits_vault_ciphertext_cap_with_margin():
+    exact_default_identity_maximum = 132_560_639
+
+    assert _vault_envelope_size(
+        plugin._MAX_PLAINTEXT_BYTES,
+        vault_id="unit-test",
+    ) < plugin._MAX_CIPHERTEXT_BYTES
+    assert _vault_envelope_size(
+        exact_default_identity_maximum,
+    ) <= plugin._MAX_CIPHERTEXT_BYTES
+    assert _vault_envelope_size(
+        exact_default_identity_maximum + 1,
+    ) > plugin._MAX_CIPHERTEXT_BYTES
+
+
+def test_real_vault_ciphertext_boundary_accepts_exact_and_rejects_one_byte_less(
     tmp_path,
     vault,
     monkeypatch,
 ):
-    path = tmp_path / "absent" / "oversize.vault.yml"
-    document = {"payload": "A" * (700 * 1024)}
-    monkeypatch.setattr(plugin, "_MAX_CIPHERTEXT_BYTES", 1024 * 1024)
-    monkeypatch.setattr(plugin, "_MAX_PLAINTEXT_BYTES", 2 * 1024 * 1024)
-    store = plugin._new_document_store(vault)
+    accepted_path = tmp_path / "accepted" / "boundary.vault.yml"
+    rejected_path = tmp_path / "rejected" / "boundary.vault.yml"
+    document = {"payload": "A" * (256 * 1024)}
+    plaintext = yaml.safe_dump(
+        document,
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=True,
+    )
+    ciphertext_bytes = len(vault.encrypt(plaintext))
+    plaintext_bytes = len(plaintext.encode("utf-8"))
+
+    monkeypatch.setattr(plugin, "_MAX_CIPHERTEXT_BYTES", ciphertext_bytes)
+    monkeypatch.setattr(plugin, "_MAX_PLAINTEXT_BYTES", plaintext_bytes)
+
+    created = plugin._new_document_store(vault).ensure_exact(
+        str(accepted_path),
+        document,
+    )
+
+    assert created["created"] is True
+    assert accepted_path.stat().st_size == ciphertext_bytes
+
+    monkeypatch.setattr(plugin, "_MAX_CIPHERTEXT_BYTES", ciphertext_bytes - 1)
 
     with pytest.raises(AnsibleActionFail):
-        store.ensure_exact(str(path), document)
+        plugin._new_document_store(vault).ensure_exact(str(rejected_path), document)
 
-    assert store._max_ciphertext_bytes == 1024 * 1024
-    assert store._max_plaintext_bytes == 2 * 1024 * 1024
-    assert not path.exists()
-    assert not path.parent.exists()
+    assert not rejected_path.exists()
+    assert not rejected_path.parent.exists()
 
 
 def test_generic_fixed_plaintext_cap_rejects_before_path_creation(

--- a/tests/unit/plugins/action/test_ansible_vault_document.py
+++ b/tests/unit/plugins/action/test_ansible_vault_document.py
@@ -162,26 +162,48 @@ def test_generic_cap_supports_large_exact_documents_on_create_read_and_race_path
     assert created["created"] is True
     assert rerun["changed"] is False
     assert race_digest == created["ciphertext_sha256"]
-    assert store._max_ciphertext_bytes == 128 * 1024 * 1024
-    assert store._max_plaintext_bytes == 128 * 1024 * 1024
+    assert store._max_ciphertext_bytes == 512 * 1024 * 1024
+    assert store._max_plaintext_bytes == 192 * 1024 * 1024
     with pytest.raises(AnsibleActionFail):
         secret_plugin._VaultSecretDocumentStore(vault).ensure_exact(str(path), document)
 
 
-def test_generic_fixed_cap_rejects_oversize_ciphertext_before_path_creation(
+def test_generic_fixed_ciphertext_cap_rejects_before_path_creation(
     tmp_path,
     vault,
     monkeypatch,
 ):
     path = tmp_path / "absent" / "oversize.vault.yml"
     document = {"payload": "A" * (700 * 1024)}
-    monkeypatch.setattr(plugin, "_MAX_DOCUMENT_BYTES", 1024 * 1024)
+    monkeypatch.setattr(plugin, "_MAX_CIPHERTEXT_BYTES", 1024 * 1024)
+    monkeypatch.setattr(plugin, "_MAX_PLAINTEXT_BYTES", 2 * 1024 * 1024)
     store = plugin._new_document_store(vault)
 
     with pytest.raises(AnsibleActionFail):
         store.ensure_exact(str(path), document)
 
     assert store._max_ciphertext_bytes == 1024 * 1024
+    assert store._max_plaintext_bytes == 2 * 1024 * 1024
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+def test_generic_fixed_plaintext_cap_rejects_before_path_creation(
+    tmp_path,
+    vault,
+    monkeypatch,
+):
+    path = tmp_path / "absent" / "oversize.vault.yml"
+    document = {"payload": "A" * ((1024 * 1024) + 1)}
+    monkeypatch.setattr(plugin, "_MAX_CIPHERTEXT_BYTES", 4 * 1024 * 1024)
+    monkeypatch.setattr(plugin, "_MAX_PLAINTEXT_BYTES", 1024 * 1024)
+    store = plugin._new_document_store(vault)
+
+    with pytest.raises(AnsibleActionFail):
+        store.ensure_exact(str(path), document)
+
+    assert store._max_ciphertext_bytes == 4 * 1024 * 1024
+    assert store._max_plaintext_bytes == 1024 * 1024
     assert not path.exists()
     assert not path.parent.exists()
 


### PR DESCRIPTION
## Summary

- split the generic Ansible Vault document safety bound into separate fixed plaintext and ciphertext limits
- set serialized plaintext to 126 MiB and Ansible Vault ciphertext to 512 MiB
- preserve non-caller-configurable limits and reject-before-publication behavior
- add real Ansible Vault envelope boundary tests and the required changelog fragment

## Why

Ansible Vault AES256 ciphertext expands serialized plaintext by about 4.05x because of padding, hex encoding, metadata, and 80-column wrapping. Under a 512 MiB ciphertext cap, the exact default-identity serialized plaintext ceiling is 132,560,639 bytes (126.4197 MiB); 192 MiB would produce about 777.60 MiB and could never fit.

The conservative 126 MiB plaintext cap leaves about 1.78 MiB of ciphertext-envelope margin for a normal named identity. Although this is nominally below the old coupled 128 MiB plaintext constant, the old 128 MiB ciphertext cap limited usable serialized plaintext to roughly 31.6 MiB. The separated limits therefore increase usable capacity by about fourfold without raising the 512 MiB memory/security envelope.

## Safety

- neither limit is exposed to callers
- oversized serialized plaintext is rejected before encryption and path creation
- oversized ciphertext is rejected before immutable publication
- exact-document validation, secret suppression, and loaded-identity handling are unchanged
- no existing issue or repository policy requires a 192 MiB plaintext document

## Validation

- focused Vault document unit suite: 41 passed
- complete action-plugin unit suite: 71 passed
- `SKIP=renovate-config-validate pre-commit run --all-files`
  - yamllint
  - ansible-lint
  - changelog policy
  - all non-heavy Molecule scenarios
  - actionlint
  - collection smoke
  - Galaxy-style role verification
- real Vault-format tests verify:
  - the envelope formula against `VaultLib.encrypt` across AES-padding and line-wrap boundaries
  - 132,560,639 bytes fits the default 512 MiB envelope and one byte more does not
  - a real encrypted document is accepted at an exact scaled ciphertext cap and rejected when the cap is one byte smaller, without creating the rejected path

The repository's Renovate hook uses mutable `docker.io/renovate/renovate:latest` and was intentionally not pulled during local validation; that baseline supply-chain concern is unrelated to this diff.
