### PR TITLE
fix: migrate promotion workflow to release App

### DIFF
--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -20,20 +20,45 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Mint release automation App token
+        id: release-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve release automation App bot identity
+        id: release-bot
+        env:
+          APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          bot_json="$(gh api "users/${APP_SLUG}%5Bbot%5D" 2>/dev/null || printf '{}')"
+          login="$(jq -r '.login // ""' <<<"$bot_json")"
+          bot_id="$(jq -r '.id // ""' <<<"$bot_json")"
+          if [ "$login" != "${APP_SLUG}[bot]" ] || ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to resolve the release automation App bot identity."
+            exit 1
+          fi
+          echo "login=$login" >>"$GITHUB_OUTPUT"
+          echo "email=${bot_id}+${login}@users.noreply.github.com" >>"$GITHUB_OUTPUT"
+
       - name: Create or update promotion PR
         env:
-          RELEASE_TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
+          RELEASE_TOKEN: ${{ steps.release-app.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           if [ -z "${RELEASE_TOKEN:-}" ]; then
-            echo "LITRELEASEBOT_TOKEN is required to create or update"
+            echo "release automation App token is required to create or update"
             echo "promotion PRs."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Copies the already-reviewed GitHub App promotion workflow from `develop` to `main` to resolve #320.

## Root cause

The organization client-ID variable was restricted to private repositories, while `main` still referenced the removed legacy release token. The variable visibility is now corrected, and this PR aligns `main` with the App-based workflow already present on `develop`.

## Validation

- The promotion workflow succeeds on `develop` after the organization variable fix.
- After merge, the workflow will be dispatched on `main` and the successful run linked in #320.

Closes #320