### PR TITLE
Delegate Foundational Heavy validation

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -139,7 +139,7 @@ jobs:
       (github.event_name == 'push' &&
        (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'))
     needs: build-candidate
-    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@a3e114b4b49eecfd74cd3981a323699ab3124114
+    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@6a78dcbd0931c7184336e7a5c6d11e6bfcc4b2d7
     with:
       profile: heavy
       matrix-json: >-

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -139,7 +139,7 @@ jobs:
       (github.event_name == 'push' &&
        (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'))
     needs: build-candidate
-    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@d509385b366829fc7ea8e335abbe29d649c2fdd5
+    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@f95f900d341d260f8fd6c9b5ab2b3b3b57bd38fa
     with:
       profile: heavy
       matrix-json: >-
@@ -157,7 +157,19 @@ jobs:
            "target":"vault-dev",
            "infrastructure":"local",
            "roles":["secret_resolver"],
-           "success_marker":"assertions/secret-resolver-vault.passed"}
+           "success_marker":"assertions/secret-resolver-vault.passed"},
+          {"runner":"ubuntu-latest",
+           "scenario":"hetzner-robot-live_heavy",
+           "target":"hetzner-robot-live",
+           "infrastructure":"external",
+           "roles":["hetzner_robot_cac"],
+           "success_marker":"assertions/hetzner-robot-live.passed"},
+          {"runner":"ubuntu-latest",
+           "scenario":"hetzner_cloud_live_heavy",
+           "target":"hetzner-cloud-live",
+           "infrastructure":"external",
+           "roles":["hetzner_cloud"],
+           "success_marker":"assertions/hetzner-cloud-live.passed"}
         ]}
       candidate-artifact: foundational-candidate-${{ github.sha }}
       source-sha: ${{ github.sha }}

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --disable-pip-version-check \
-            "ansible-core==2.18.18"
+            "ansible-core==2.18.13"
           mkdir -p dist/candidate
           ansible-galaxy collection build --output-path dist/candidate --force
           mapfile -t candidates < <(
@@ -176,7 +176,12 @@ jobs:
       collection-namespace: lit
       collection-name: foundational
       environment-name: ansible-collections
-    secrets: inherit
+    secrets:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+      HROBOT_LIVE_USER: ${{ secrets.HROBOT_LIVE_USER }}
+      HROBOT_LIVE_PASSWORD: ${{ secrets.HROBOT_LIVE_PASSWORD }}
+      HROBOT_LIVE_SERVER_IP: ${{ secrets.HROBOT_LIVE_SERVER_IP }}
+      HROBOT_LIVE_SERVER_NAME: ${{ secrets.HROBOT_LIVE_SERVER_NAME }}
 
   heavy:
     name: Collection / Heavy

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -9,6 +9,7 @@ on:
     tags: ["v*"]
   # CI on all PRs
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -92,3 +93,100 @@ jobs:
           EXAMPLE_PLAYBOOK_ARGS: ${{ env.EXAMPLE_PLAYBOOK_ARGS }}
         run: |
           bash scripts/devtools-collection-smoke.sh
+
+  build-candidate:
+    name: Build immutable Heavy candidate
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Build and checksum exact collection candidate
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            "ansible-core==2.18.18"
+          mkdir -p dist/candidate
+          ansible-galaxy collection build --output-path dist/candidate --force
+          mapfile -t candidates < <(
+            find dist/candidate -maxdepth 1 -type f -name '*.tar.gz' -print
+          )
+          test "${#candidates[@]}" -eq 1
+          (
+            cd dist/candidate
+            sha256sum "$(basename "${candidates[0]}")" > candidate-SHA256SUMS
+            sha256sum --check candidate-SHA256SUMS
+          )
+      - name: Upload exact candidate
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: foundational-candidate-${{ github.sha }}
+          path: dist/candidate/
+          if-no-files-found: error
+          retention-days: 7
+
+  heavy-cells:
+    name: Heavy matrix (delegated to modulix-validation)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'))
+    needs: build-candidate
+    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@d509385b366829fc7ea8e335abbe29d649c2fdd5
+    with:
+      profile: heavy
+      matrix-json: >-
+        {"include":[
+          {"runner":["self-hosted","linux","x64","incus"],
+           "scenario":"hetzner-cloud-incus_heavy",
+           "target":"ubuntu-24.04",
+           "infrastructure":"incus",
+           "image":"images:ubuntu/24.04",
+           "instance_type":"container",
+           "roles":["hetzner_cloud"],
+           "success_marker":"assertions/hetzner-cloud-incus.passed"},
+          {"runner":"ubuntu-latest",
+           "scenario":"secret-resolver-vault-integration_heavy",
+           "target":"vault-dev",
+           "infrastructure":"local",
+           "roles":["secret_resolver"],
+           "success_marker":"assertions/secret-resolver-vault.passed"}
+        ]}
+      candidate-artifact: foundational-candidate-${{ github.sha }}
+      source-sha: ${{ github.sha }}
+      collection-namespace: lit
+      collection-name: foundational
+      environment-name: ansible-collections
+    secrets: inherit
+
+  heavy:
+    name: Collection / Heavy
+    if: always()
+    needs: [build-candidate, heavy-cells]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Heavy when the protected matrix is selected
+        env:
+          BUILD_RESULT: ${{ needs.build-candidate.result }}
+          HEAVY_RESULT: ${{ needs.heavy-cells.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          test "$BUILD_RESULT" = success
+          if [ "$EVENT_NAME" = workflow_dispatch ] ||
+            { [ "$EVENT_NAME" = push ] &&
+              { [ "$GIT_REF" = refs/heads/develop ] ||
+                [ "$GIT_REF" = refs/heads/main ]; }; }
+          then
+            test "$HEAVY_RESULT" = success
+          else
+            test "$HEAVY_RESULT" = skipped
+          fi

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -139,7 +139,7 @@ jobs:
       (github.event_name == 'push' &&
        (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'))
     needs: build-candidate
-    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@c1d10884dd80357698242996502ea81f2eadefc7
+    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@a3e114b4b49eecfd74cd3981a323699ab3124114
     with:
       profile: heavy
       matrix-json: >-
@@ -152,19 +152,19 @@ jobs:
            "instance_type":"container",
            "roles":["hetzner_cloud"],
            "success_marker":"assertions/hetzner-cloud-incus.passed"},
-          {"runner":"ubuntu-latest",
+          {"runner":["self-hosted","linux","x64"],
            "scenario":"secret-resolver-vault-integration_heavy",
            "target":"vault-dev",
            "infrastructure":"local",
            "roles":["secret_resolver"],
            "success_marker":"assertions/secret-resolver-vault.passed"},
-          {"runner":"ubuntu-latest",
+          {"runner":["self-hosted","linux","x64"],
            "scenario":"hetzner-robot-live_heavy",
            "target":"hetzner-robot-live",
            "infrastructure":"external",
            "roles":["hetzner_robot_cac"],
            "success_marker":"assertions/hetzner-robot-live.passed"},
-          {"runner":"ubuntu-latest",
+          {"runner":["self-hosted","linux","x64"],
            "scenario":"hetzner_cloud_live_heavy",
            "target":"hetzner-cloud-live",
            "infrastructure":"external",

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -139,7 +139,7 @@ jobs:
       (github.event_name == 'push' &&
        (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main'))
     needs: build-candidate
-    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@f95f900d341d260f8fd6c9b5ab2b3b3b57bd38fa
+    uses: lightning-it/modulix-validation/.github/workflows/collection-molecule-profile.yml@c1d10884dd80357698242996502ea81f2eadefc7
     with:
       profile: heavy
       matrix-json: >-

--- a/TESTING.md
+++ b/TESTING.md
@@ -51,17 +51,12 @@ Their protected execution is owned exclusively by the commit-pinned reusable
 workflow in `lightning-it/modulix-validation`, in accordance with the accepted
 [Modulix test execution ownership ADR](https://wiki.cloud.l-it.io/wiki/spaces/LIT/pages/2886566105).
 
-The required central matrix currently contains the executable Incus floating-IP
-scenario and the disposable local Vault integration scenario. Each must write a
-post-assertion success marker; a skipped or incomplete scenario therefore
-cannot pass. The exact candidate archive and source SHA are recorded in
-normalized evidence.
-
-The `hetzner-robot-live_heavy` and `hetzner_cloud_live_heavy` scenarios remain
-versioned here but are not release-required until the protected environment has
-the documented narrowly scoped Hetzner credentials. They are never executed by
-a collection-owned workflow and must not be represented as passing through a
-skip.
+The required central matrix contains every routed Heavy scenario: Incus
+floating-IP, disposable Vault integration, read-only Hetzner Robot audit, and
+disposable Hetzner Cloud infrastructure. Each writes a post-assertion success
+marker; a missing protected credential, skipped scenario, or incomplete
+verification therefore cannot pass. The exact candidate archive and source SHA
+are recorded in normalized evidence.
 
 ## Interpreting GitHub Actions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -44,6 +44,25 @@ bash scripts/wunder-devtools-ee.sh true
 
 Heavy Incus tests require an Ubuntu host or runner with Incus available, suitable images, and repository-specific scenario configuration. Heavy tests must use sanitized inputs and must not rely on private inventory values.
 
+## Heavy execution ownership
+
+Heavy scenarios and their component assertions remain in this repository.
+Their protected execution is owned exclusively by the commit-pinned reusable
+workflow in `lightning-it/modulix-validation`, in accordance with the accepted
+[Modulix test execution ownership ADR](https://wiki.cloud.l-it.io/wiki/spaces/LIT/pages/2886566105).
+
+The required central matrix currently contains the executable Incus floating-IP
+scenario and the disposable local Vault integration scenario. Each must write a
+post-assertion success marker; a skipped or incomplete scenario therefore
+cannot pass. The exact candidate archive and source SHA are recorded in
+normalized evidence.
+
+The `hetzner-robot-live_heavy` and `hetzner_cloud_live_heavy` scenarios remain
+versioned here but are not release-required until the protected environment has
+the documented narrowly scoped Hetzner credentials. They are never executed by
+a collection-owned workflow and must not be represented as passing through a
+skip.
+
 ## Interpreting GitHub Actions
 
 The GitHub Actions matrix is the primary dashboard. Job names should expose the repository class, OS/runtime, and profile, for example `ansible / rhel9 / molecule-heavy-incus` or `container / ubuntu / build-smoke`.

--- a/changelogs/fragments/delegate-heavy-validation.yml
+++ b/changelogs/fragments/delegate-heavy-validation.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    Delegate required Heavy execution to the pinned ``modulix-validation``
+    reusable workflow with an immutable candidate, meaningful success markers,
+    owner-scoped cleanup, and normalized evidence.

--- a/molecule/hetzner-cloud-incus_heavy/molecule.yml
+++ b/molecule/hetzner-cloud-incus_heavy/molecule.yml
@@ -7,11 +7,11 @@ driver:
   name: default
 
 platforms:
-  - name: lit-hetzner-cloud-floating-ip-ct
-    image: images:ubuntu/24.04
-    type: container
-    network: lit-hc-fip-net
-    owner: lit-foundational-hetzner-cloud-incus-heavy
+  - name: "${MOLECULE_TEST_INSTANCE:-lit-hetzner-cloud-floating-ip-ct}"
+    image: "${MOLECULE_TEST_IMAGE:-images:ubuntu/24.04}"
+    type: "${MOLECULE_TEST_INSTANCE_TYPE:-container}"
+    network: "${MOLECULE_TEST_NETWORK:-lit-hc-fip-net}"
+    owner: "${MOLECULE_TEST_OWNER:-lit-foundational-hetzner-cloud-incus-heavy}"
 
 provisioner:
   name: ansible

--- a/molecule/hetzner-cloud-incus_heavy/molecule.yml
+++ b/molecule/hetzner-cloud-incus_heavy/molecule.yml
@@ -17,7 +17,7 @@ provisioner:
   name: ansible
   inventory:
     host_vars:
-      lit-hetzner-cloud-floating-ip-ct:
+      "${MOLECULE_TEST_INSTANCE:-lit-hetzner-cloud-floating-ip-ct}":
         ansible_connection: community.general.incus
         ansible_python_interpreter: /usr/bin/python3
   playbooks:

--- a/molecule/hetzner-cloud-incus_heavy/verify.yml
+++ b/molecule/hetzner-cloud-incus_heavy/verify.yml
@@ -55,3 +55,15 @@
           - hetzner_cloud_guest_floating_ip_status.incus_missing.manual_configuration_required | bool
         quiet: true
       changed_when: false
+
+    - name: Record successful meaningful Heavy verification
+      ansible.builtin.copy:
+        content: "hetzner-cloud-incus verified\n"
+        dest: >-
+          {{
+            lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER')
+            | default('/tmp/hetzner-cloud-incus-heavy.passed', true)
+          }}
+        mode: "0600"
+      delegate_to: localhost
+      become: false

--- a/molecule/hetzner-cloud-incus_heavy/verify.yml
+++ b/molecule/hetzner-cloud-incus_heavy/verify.yml
@@ -56,14 +56,18 @@
         quiet: true
       changed_when: false
 
+    - name: Require centrally provided Heavy success marker
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER') | length > 0
+        fail_msg: MOLECULE_TEST_SUCCESS_MARKER must be provided by central orchestration.
+      delegate_to: localhost
+      become: false
+
     - name: Record successful meaningful Heavy verification
       ansible.builtin.copy:
         content: "hetzner-cloud-incus verified\n"
-        dest: >-
-          {{
-            lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER')
-            | default('/tmp/hetzner-cloud-incus-heavy.passed', true)
-          }}
+        dest: "{{ lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER') }}"
         mode: "0600"
       delegate_to: localhost
       become: false

--- a/molecule/hetzner-robot-live_heavy/verify.yml
+++ b/molecule/hetzner-robot-live_heavy/verify.yml
@@ -40,3 +40,11 @@
         quiet: true
       changed_when: false
       no_log: true
+
+    - name: Record successful meaningful Heavy verification
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'MOLECULE_TEST_SUCCESS_MARKER') }}"
+        mode: "0600"
+        content: "hetzner-robot-live verified\n"
+      delegate_to: localhost
+      no_log: true

--- a/molecule/hetzner_cloud_live_heavy/verify.yml
+++ b/molecule/hetzner_cloud_live_heavy/verify.yml
@@ -107,3 +107,11 @@
         quiet: true
       changed_when: false
       no_log: true
+
+    - name: Record successful meaningful Heavy verification
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'MOLECULE_TEST_SUCCESS_MARKER') }}"
+        mode: "0600"
+        content: "hetzner-cloud-live verified\n"
+      delegate_to: localhost
+      no_log: true

--- a/molecule/secret-resolver-vault-integration_heavy/verify.yml
+++ b/molecule/secret-resolver-vault-integration_heavy/verify.yml
@@ -187,13 +187,16 @@
         quiet: true
       no_log: true
 
+    - name: Require centrally provided Heavy success marker
+      ansible.builtin.assert:
+        that:
+          - lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER') | length > 0
+        fail_msg: MOLECULE_TEST_SUCCESS_MARKER must be provided by central orchestration.
+      no_log: true
+
     - name: Record successful meaningful Heavy verification
       ansible.builtin.copy:
         content: "secret-resolver-vault verified\n"
-        dest: >-
-          {{
-            lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER')
-            | default('/tmp/secret-resolver-vault-heavy.passed', true)
-          }}
+        dest: "{{ lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER') }}"
         mode: "0600"
       no_log: true

--- a/molecule/secret-resolver-vault-integration_heavy/verify.yml
+++ b/molecule/secret-resolver-vault-integration_heavy/verify.yml
@@ -186,3 +186,14 @@
           - secret_resolver_check_mode_document.json.data.metadata.version == 1
         quiet: true
       no_log: true
+
+    - name: Record successful meaningful Heavy verification
+      ansible.builtin.copy:
+        content: "secret-resolver-vault verified\n"
+        dest: >-
+          {{
+            lookup('ansible.builtin.env', 'MOLECULE_TEST_SUCCESS_MARKER')
+            | default('/tmp/secret-resolver-vault-heavy.passed', true)
+          }}
+        mode: "0600"
+      no_log: true


### PR DESCRIPTION
## Summary

- build and checksum an immutable collection candidate
- delegate all four routed Heavy scenarios: Incus floating IP, Vault integration, read-only Hetzner Robot, and disposable Hetzner Cloud
- pin the complete generic `modulix-validation` contract and require protected credentials for live cells
- require post-assertion success markers and a fail-closed aggregate
- make infrastructure identities run-unique and centrally owner-scoped
- document ADR 2886566105

## Validation

- actionlint and yamllint passed locally
- all routed `*_heavy` and `protected-incus` scenarios are present in the machine-readable matrix
- GitHub lint, candidate build, smoke, changelog, CodeQL, and standard Molecule checks run on every revision
- `git diff --check` passed

Closes #341